### PR TITLE
Update interactive Wilson

### DIFF
--- a/tools/interactive/interactivetool_wilson.xml
+++ b/tools/interactive/interactivetool_wilson.xml
@@ -14,8 +14,8 @@
     </environment_variables>
     <command><![CDATA[
         mkdir -p /srv/shiny-server/external_data/ &&
-        echo $WILSON_LANDING_PAGE > /home/shiny/.Renviron &&
-        echo $WILSON_BLACKLIST_EXAMPLES >> /home/shiny/.Renviron &&
+        echo "WILSON_LANDING_PAGE=\$WILSON_LANDING_PAGE" > /home/shiny/.Renviron &&
+        echo "WILSON_BLACKLIST_EXAMPLES=\$WILSON_BLACKLIST_EXAMPLES" >> /home/shiny/.Renviron &&
         ln -s ${infile} /srv/shiny-server/external_data/input.clarion &&
         exec shiny-server 2>&1
     ]]>

--- a/tools/interactive/interactivetool_wilson.xml
+++ b/tools/interactive/interactivetool_wilson.xml
@@ -1,7 +1,7 @@
 <tool id="interactive_tool_wilson" tool_type="interactive" name="Wilson" version="0.1">
     <description>Webbased Interactive Omics visualization</description>
     <requirements>
-        <container type="docker">quay.io/bgruening/wilson-app</container>
+        <container type="docker">loosolab/wilson:2.1.1</container>
     </requirements>
     <entry_points>
         <entry_point name="Wilson visualisation of $infile.display_name" requires_domain="True">
@@ -10,9 +10,12 @@
     </entry_points>
     <environment_variables>
         <environment_variable name="WILSON_LANDING_PAGE">feature_selection</environment_variable>
+        <environment_variable name="WILSON_BLACKLIST_EXAMPLES">true</environment_variable>
     </environment_variables>
     <command><![CDATA[
         mkdir -p /srv/shiny-server/external_data/ &&
+        echo $WILSON_LANDING_PAGE > /home/shiny/.Renviron &&
+        echo $WILSON_BLACKLIST_EXAMPLES >> /home/shiny/.Renviron &&
         ln -s ${infile} /srv/shiny-server/external_data/input.clarion &&
         exec shiny-server 2>&1
     ]]>


### PR DESCRIPTION
Hi,

* The container has been updated to `2.1.1`.
* The new container version allows blacklisting of examples, those will not be shown in the list of datasets anymore if `WILSON_BLACKLIST_EXAMPLES` is set to `true`, `1` etc.
* The container command now contains instructions to add the environment variables to the file `/home/shiny/.Renviron`.

Another idea: Instead of using the static filename `input.clarion`, would it be possible to use e.g. `${infile.display_name}`?

Best,
Jens