### PR TITLE
Askomics IT: fix env var name + update

### DIFF
--- a/tools/interactive/interactivetool_askomics.xml
+++ b/tools/interactive/interactivetool_askomics.xml
@@ -1,7 +1,7 @@
 <tool id="interactive_tool_askomics" tool_type="interactive" name="AskOmics" version="1.0">
     <description>a visual SPARQL query builder</description>
     <requirements>
-        <container type="docker">askomics/flaskomics-with-dependencies:3.1.1</container>
+        <container type="docker">askomics/flaskomics-with-dependencies:3.2.0</container>
     </requirements>
     <entry_points>
         <entry_point name="AskOmics instance on $infile.display_name" requires_domain="True">
@@ -19,7 +19,7 @@
         <environment_variable name="USER_APIKEY">${__user_name__}</environment_variable>
         <!-- Galaxy info -->
         <environment_variable name="GALAXY_URL">$__galaxy_url__</environment_variable>
-        <environment_variable name="API_KEY" inject="api_key" />
+        <environment_variable name="GALAXY_API_KEY" inject="api_key" />
         <!-- AskOmics config -->
         <environment_variable name="DEPMODE">prod</environment_variable>
         <environment_variable name="MAX_CELERY_QUEUE">1</environment_variable>


### PR DESCRIPTION
Hi!
We've set up interactive tools on galaxy.genouest.org, and found out that the AskOmics IT was not fully working due to a bad env var name, so here's a fix
Also updated to AskOmics 3.2.0, following @xgaia advice