### PR TITLE
add panoply as new interative tool

### DIFF
--- a/tools/interactive/interactivetool_panoply.xml
+++ b/tools/interactive/interactivetool_panoply.xml
@@ -1,0 +1,28 @@
+<tool id="interactive_tool_panoply" tool_type="interactive" name="panoply" version="0.1">
+    <requirements>
+        <container type="docker">quay.io/nordicesmhub/docker-panoply</container>
+    </requirements>
+    <entry_points>
+        <entry_point name="Panoply on $infile.display_name" requires_domain="True">
+            <port>5800</port>
+        </entry_point>
+    </entry_points>
+    <command><![CDATA[
+        rm /opt/data/* -rf &&
+        cp '$infile' /opt/data/'$infile.display_name' &&
+        cd /opt/data &&
+        /opt/PanoplyJ/panoply.sh
+    ]]>
+    </command>
+    <inputs>
+        <param name="infile" type="data" format="netcdf,h5" label="netcdf"/>
+    </inputs>
+    <outputs>
+        <data name="outfile" format="png" />
+    </outputs>
+    <tests>
+    </tests>
+    <help>
+        `Panoply <https://www.giss.nasa.gov/tools/panoply/>`_ plots geo-referenced and other arrays from netCDF, HDF, GRIB, and other datasets.
+    </help>
+</tool>


### PR DESCRIPTION
It is my first attempt to add [Panoply](https://www.giss.nasa.gov/tools/panoply/) as a new interactive tool. 

I am sure I have it wrong but I did not manage to have a proper setup to test it locally.

- Source for the docker image:  https://github.com/NordicESMhub/docker-panoply

We plan to use it for analyzing Copernicus Climate data ([training on the 6th of March](https://climate.copernicus.eu/c3s-user-learning-services-training-event-norway-sweden)).