### PR TITLE
use get to copy data/notebook for jupyterlab

### DIFF
--- a/tools/interactive/interactivetool_climate_notebook.xml
+++ b/tools/interactive/interactivetool_climate_notebook.xml
@@ -1,4 +1,4 @@
-<tool id="interactive_tool_climate_notebook" tool_type="interactive" name="Interactive Climate Notebook" version="0.3">
+<tool id="interactive_tool_climate_notebook" tool_type="interactive" name="Interactive Climate Notebook" version="0.2">
     <requirements>
         <container type="docker">nordicesmhub/docker-climate-notebook:1.2</container>
     </requirements>

--- a/tools/interactive/interactivetool_climate_notebook.xml
+++ b/tools/interactive/interactivetool_climate_notebook.xml
@@ -1,4 +1,4 @@
-<tool id="interactive_tool_climate_notebook" tool_type="interactive" name="Interactive Climate Notebook" version="0.2">
+<tool id="interactive_tool_climate_notebook" tool_type="interactive" name="Interactive Climate Notebook" version="0.3">
     <requirements>
         <container type="docker">nordicesmhub/docker-climate-notebook:1.2</container>
     </requirements>
@@ -23,7 +23,8 @@
 
         #if $input:
             #set $cleaned_name = re.sub('[^\w\-\.]', '_', str($input.element_identifier))
-            cp '$input' './jupyter/data/${cleaned_name}' &&
+	    get -t name -i '${cleaned_name}' &&
+	    ln -sf '/import/${cleaned_name}' './jupyter/data/${cleaned_name}' &&
         #end if
 
         ## change into the directory where the notebooks are located
@@ -32,15 +33,15 @@
 
         #if $mode.mode_select == 'scratch':
             ## copy default notebook
-            cp '$__tool_directory__/default_notebook.ipynb' ./ipython_galaxy_notebook.ipynb &&
+            cp '/home/jovyan/default_notebook.ipynb' ./ipython_galaxy_notebook.ipynb &&
             jupyter trust ./ipython_galaxy_notebook.ipynb &&
             jupyter lab --allow-root --no-browser --NotebookApp.shutdown_button=True &&
             cp ./ipython_galaxy_notebook.ipynb '$jupyter_notebook'
 
         #else:
-            #set $cleaned_name = re.sub('[^\w\-\.]', '_', str($input.element_identifier))
-            cp '$mode.ipynb' ./${cleaned_name}.ipynb &&
-            jupyter trust ./${cleaned_name}.ipynb &&
+            #set $cleaned_name = re.sub('[^\w\-\.]', '_', str($mode.ipynb.element_identifier))
+            cp '$mode.ipynb' ./${cleaned_name} &&
+            jupyter trust ./${cleaned_name} &&
 
             #if $mode.run_it:
                 jupyter nbconvert --to notebook --execute --output ./ipython_galaxy_notebook.ipynb --allow-errors  ./*.ipynb &&

--- a/tools/interactive/interactivetool_climate_notebook.xml
+++ b/tools/interactive/interactivetool_climate_notebook.xml
@@ -23,7 +23,7 @@
 
         #if $input:
             #set $cleaned_name = re.sub('[^\w\-\.]', '_', str($input.element_identifier))
-	    get -t name -i '${input.hid}' &&
+	    get -t hid -i '${input.hid}' &&
 	    ln -sf '/import/${input.hid}' './jupyter/data/${cleaned_name}' &&
         #end if
 
@@ -40,7 +40,7 @@
 
         #else:
             #set $cleaned_name = re.sub('[^\w\-\.]', '_', str($mode.ipynb.element_identifier))
-	    get -t name -i '${mode.ipynb.hid}' &&
+	    get -t hid -i '${mode.ipynb.hid}' &&
 	    ln -sf '/import/${mode.ipynb.hid}' './jupyter/data/${cleaned_name}' &&
             jupyter trust ./${cleaned_name} &&
 

--- a/tools/interactive/interactivetool_climate_notebook.xml
+++ b/tools/interactive/interactivetool_climate_notebook.xml
@@ -23,8 +23,8 @@
 
         #if $input:
             #set $cleaned_name = re.sub('[^\w\-\.]', '_', str($input.element_identifier))
-	    get -t name -i '${cleaned_name}' &&
-	    ln -sf '/import/${cleaned_name}' './jupyter/data/${cleaned_name}' &&
+	    get -t name -i '${input.hid}' &&
+	    ln -sf '/import/${input.hid}' './jupyter/data/${cleaned_name}' &&
         #end if
 
         ## change into the directory where the notebooks are located
@@ -40,7 +40,8 @@
 
         #else:
             #set $cleaned_name = re.sub('[^\w\-\.]', '_', str($mode.ipynb.element_identifier))
-            cp '$mode.ipynb' ./${cleaned_name} &&
+	    get -t name -i '${mode.ipynb.hid}' &&
+	    ln -sf '/import/${mode.ipynb.hid}' './jupyter/data/${cleaned_name}' &&
             jupyter trust ./${cleaned_name} &&
 
             #if $mode.run_it:


### PR DESCRIPTION
Shouldn't we use `get` to copy data and existing jupyter notebooks?

I am not sure I got it right (I do not manage to test it with planemo) but locally the usage of `get` works well.