### PR TITLE
Reduce page size

### DIFF
--- a/config/plugins/visualizations/chiraviz/static/js/rna-viz.js
+++ b/config/plugins/visualizations/chiraviz/static/js/rna-viz.js
@@ -9,8 +9,7 @@ in multiple plots, comic alignments
 var RNAInteractionViewer = (function(riv) {
   riv.configObject = null;
   riv.model = null;
-  riv.showRecords = 50;
-  riv.nIncrement = 50;
+  riv.nIncrement = 25;
   riv.counterRecords = 0;
   riv.minQueryLength = 3;
   riv.type1 = null;


### PR DESCRIPTION
This PR reduces the number of records from 50 to 25 shown per page (for more records, Galaxy is responding with 502 error)

![502_error](https://user-images.githubusercontent.com/3022518/77305885-14359800-6cf7-11ea-8b97-af0fa781a81d.png)

Only one copy of https://github.com/usegalaxy-eu/galaxy/tree/release_19.09_europe/config/plugins/visualizations/chiraviz folder should be copied to https://github.com/usegalaxy-eu/galaxy/tree/release_19.09_europe/static/plugins/visualizations

But, I see them copied twice. It should have only one copy viz's the static folder like other visualisations.

![copies](https://user-images.githubusercontent.com/3022518/77306085-6c6c9a00-6cf7-11ea-8989-b3b2cbface30.png)

ping @bgruening 