### PR TITLE
Tool recommendation: Add query strings

### DIFF
--- a/client/galaxy/scripts/components/ToolRecommendation.vue
+++ b/client/galaxy/scripts/components/ToolRecommendation.vue
@@ -219,7 +219,10 @@ export default {
                 update(d);
                 const tId = d.tool_id;
                 if (tId !== undefined && tId !== "undefined" && tId !== null && tId !== "") {
-                    document.location.href = `${getAppRoot()}tool_runner?tool_id=${tId}`;
+                    const utc = new Date();
+                    const timeId = utc.getTime();
+                    document.location.href =
+                        `${getAppRoot()}root?tool_id=${tId}&origin=tool_recommendation&utc=` + timeId;
                 }
             };
             const collapse = (d) => {

--- a/client/galaxy/scripts/components/Workflow/Editor/services.js
+++ b/client/galaxy/scripts/components/Workflow/Editor/services.js
@@ -78,7 +78,12 @@ export async function getDatatypeMapping() {
 
 export async function getToolPredictions(requestData) {
     try {
-        const response = await axios.post(`${getAppRoot()}api/workflows/get_tool_predictions`, requestData);
+        const utc = new Date();
+        const timeId = utc.getTime();
+        const response = await axios.post(
+            `${getAppRoot()}api/workflows/get_tool_predictions?origin=tool_recommendation&utc=` + timeId,
+            requestData
+        );
         return response.data;
     } catch (e) {
         rethrowSimple(e);


### PR DESCRIPTION
This PR adds query strings to the URLs fetching tool recommendations in order to get statistics of the system's usage over time by searching for specific keywords in the Galaxy logs.