### PR TITLE
upgrade Galaxy Climate JupyterLab interactive tool

### DIFF
--- a/tools/interactive/interactivetool_climate_notebook.xml
+++ b/tools/interactive/interactivetool_climate_notebook.xml
@@ -1,6 +1,6 @@
-<tool id="interactive_tool_climate_notebook" tool_type="interactive" name="Interactive Climate Notebook" version="0.2">
+<tool id="interactive_tool_climate_notebook" tool_type="interactive" name="Interactive Climate Notebook" version="0.3">
     <requirements>
-        <container type="docker">nordicesmhub/docker-climate-notebook:1.2</container>
+        <container type="docker">quay.io/nordicesmhub/docker-climate-notebook:2021-03-15</container>
     </requirements>
     <entry_points>
         <entry_point name="Climate Interactive Tool" requires_domain="True">


### PR DESCRIPTION
- Base image is now scipy notebook so that we can have pangeo notebook by default (not compatible with pangeo notebook image.
- Remove additional kernels (julia, R) as there were not specific to climate (no specific packages); we can use the default interactive jupyterLab if needed.
- This new container has updated versions of packages for Pangeo, cesm and esmvaltool.