### PR TITLE
fix problem with Climate jupyterLab tutorial

### DIFF
--- a/tools/interactive/interactivetool_climate_notebook.xml
+++ b/tools/interactive/interactivetool_climate_notebook.xml
@@ -1,6 +1,6 @@
-<tool id="interactive_tool_climate_notebook" tool_type="interactive" name="Interactive Climate Notebook" version="0.3">
+<tool id="interactive_tool_climate_notebook" tool_type="interactive" name="Interactive Climate Notebook" version="0.4">
     <requirements>
-        <container type="docker">quay.io/nordicesmhub/docker-climate-notebook:2021-03-15</container>
+        <container type="docker">quay.io/nordicesmhub/docker-climate-notebook:2021-03-18</container>
     </requirements>
     <entry_points>
         <entry_point name="Climate Interactive Tool" requires_domain="True">


### PR DESCRIPTION
- USER environment variable needs to be defined for running FATES in JupyterLab and this environment
variable was missing in the newly created docker (was removed by mistake during last upgrade).
- remove jupyterlab-git extension which does not work for this latest version of JupyterLab