### PR TITLE
Add VRM Editor interactive tool (Climate) in release 21.01 europe

### DIFF
--- a/tools/interactive/interactivetool_vrm_editor.xml
+++ b/tools/interactive/interactivetool_vrm_editor.xml
@@ -28,7 +28,7 @@
     ]]>
     </command>
     <inputs>
-        <param name="infile" type="data" format="txt,netcdf,h5" label="input"/>
+        <param name="infile" type="data" format="txt,netcdf,h5" label="input" optional="true" />
     </inputs>
     <outputs>
         <collection name="outputs" type="list" label="VRM Editor outputs">

--- a/tools/interactive/interactivetool_vrm_editor.xml
+++ b/tools/interactive/interactivetool_vrm_editor.xml
@@ -1,0 +1,44 @@
+<tool id="interactive_tool_vrm_editor" tool_type="interactive" name="VRM Editor" version="@VERSION@">
+    <description>interative tool for creating Variable Resolution Mesh for NorESM/CESM</description>
+    <macros>
+    <token name="@VERSION@">0.2.1</token>
+    </macros>
+    <requirements>
+        <container type="docker">quay.io/nordicesmhub/docker-vrm-editor:@VERSION@</container>
+    </requirements>
+    <entry_points>
+        <entry_point name="VRM Editor with $infile.display_name" requires_domain="True">
+            <port>5800</port>
+        </entry_point>
+    </entry_points>
+    <command detect_errors="exit_code">
+    <![CDATA[
+    mkdir output &&
+        mkdir /config/home  &&
+        mkdir /config/home/output &&
+        export HOME=/config/home &&
+        cp '$infile' '/config/home/$infile.display_name' &&
+        /init ;
+        echo "Galaxy VRM Editor version @VERSION@" > output/version.txt &&
+        cp /config/home/output/* output/ | true &&
+        cd output &&
+        sleep 2 &&
+        for file in *; do mv "\$file" "\${file// /_}"; done &&
+        for file in *; do mv "\$file" "\$file.\${file\#\#*.}"; done
+    ]]>
+    </command>
+    <inputs>
+        <param name="infile" type="data" format="txt,netcdf,h5" label="input"/>
+    </inputs>
+    <outputs>
+        <collection name="outputs" type="list" label="VRM Editor outputs">
+            <discover_datasets pattern="__name_and_ext__" directory="output" />
+        </collection>
+    </outputs>
+    <tests>
+    </tests>
+    <help><![CDATA[
+        `VRM Editor <https://github.com/ESMCI/Community_Mesh_Generation_Toolkit>`_ is a tool to create Variable Resolution Spectral Element Grids in CESM/NorESM.
+    ]]>
+    </help>
+</tool>


### PR DESCRIPTION
### Interactive Climate Tool for creating Variable Resolution Mesh for NorESM/CESM climate models.

- Docker container is on quay.io (see https://github.com/NordicESMhub/docker-vrm-editor for more information).
- The tool has an optional parameter which is an existing grid or description of a grid. When no parameter is given, one needs to create a new grid from scratch.
- The generated grid is a netCDF file that can be used for running CESM or NorESM climate models.
- I tested the docker container but unfortunately did not manage to test the interactive tool locally with my galaxy test instance.