### PR TITLE
[BACKPORT] Change requirement condition to both options.

### DIFF
--- a/lib/galaxy/files/__init__.py
+++ b/lib/galaxy/files/__init__.py
@@ -245,16 +245,19 @@ class ProvidesUserFileSourcesUserContext:
 
     @property
     def role_names(self):
+        """The set of role names of this user."""
         user = self.trans.user
         return user and set([ura.role.name for ura in user.roles])
 
     @property
     def group_names(self):
+        """The set of group names to which this user belongs."""
         user = self.trans.user
         return user and set([ugr.group.name for ugr in user.groups])
 
     @property
     def is_admin(self):
+        """Whether this user is an administrator."""
         return self.trans.user_is_admin
 
 

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -71,10 +71,13 @@ class BaseFilesSource(FilesSource):
         return self.writable
 
     def user_has_access(self, user_context) -> bool:
-        return user_context is None or (
-            user_context.is_admin
-            or self._user_has_required_roles(user_context)
-            or self._user_has_required_groups(user_context)
+        return (
+            user_context is None
+            or user_context.is_admin
+            or (
+                self._user_has_required_roles(user_context)
+                and self._user_has_required_groups(user_context)
+            )
         )
 
     def get_uri_root(self):


### PR DESCRIPTION
If the `requires_roles` and `requires_groups` options are defined, both must be satisfied.

Missing commit from https://github.com/usegalaxy-eu/galaxy/pull/98