### PR TITLE
add interactive tool for pangeo notebook from Pangeo community

### DIFF
--- a/tools/interactive/interactivetool_pangeo_notebook.xml
+++ b/tools/interactive/interactivetool_pangeo_notebook.xml
@@ -1,0 +1,102 @@
+<tool id="interactive_tool_pangeo_notebook" tool_type="interactive" name="Interactive Pangeo Notebook" version="1c0f66b">
+    <requirements>
+        <container type="docker">quay.io/nordicesmhub/docker-pangeo-notebook:1c0f66b</container>
+    </requirements>
+    <entry_points>
+        <entry_point name="Pangeo Interactive Tool" requires_domain="True">
+            <port>8888</port>
+            <url>ipython/lab</url>
+        </entry_point>
+    </entry_points>
+    <environment_variables>
+        <environment_variable name="HISTORY_ID">$__history_id__</environment_variable>
+        <environment_variable name="REMOTE_HOST">$__galaxy_url__</environment_variable>
+        <environment_variable name="GALAXY_WEB_PORT">8080</environment_variable>
+        <environment_variable name="GALAXY_URL">$__galaxy_url__</environment_variable>
+        <environment_variable name="API_KEY" inject="api_key" />
+    </environment_variables>
+    <command detect_errors="aggressive"><![CDATA[
+        #import re
+        export GALAXY_WORKING_DIR=`pwd` &&
+        mkdir -p ./jupyter/outputs/ &&
+        mkdir -p ./jupyter/data &&
+
+        #if $input:
+            #set $cleaned_name = re.sub('[^\w\-\.]', '_', str($input.element_identifier))
+            get -t hid -i '${input.hid}' &&
+            ln -sf '/import/${input.hid}' './jupyter/data/${cleaned_name}' &&
+        #end if
+
+        ## change into the directory where the notebooks are located
+        cd ./jupyter/ &&
+        export HOME=/home/jovyan/ &&
+        export PATH=/home/jovyan/.local/bin:\$PATH &&
+
+        #if $mode.mode_select == 'scratch':
+            ## copy default notebook
+            cp '$__tool_directory__/default_notebook.ipynb' ./ipython_galaxy_notebook.ipynb &&
+            jupyter trust ./ipython_galaxy_notebook.ipynb &&
+            jupyter lab --allow-root --no-browser --NotebookApp.shutdown_button=True &&
+            cp ./ipython_galaxy_notebook.ipynb '$jupyter_notebook'
+
+        #else:
+            #set $cleaned_name = re.sub('[^\w\-\.]', '_', str($mode.ipynb.element_identifier))
+            get -t hid -i '${mode.ipynb.hid}' &&
+            ln -sf '/import/${mode.ipynb.hid}' './data/${cleaned_name}' &&
+            jupyter trust ./data/${cleaned_name} &&
+
+            #if $mode.run_it:
+                jupyter nbconvert --to notebook --execute --output ./ipython_galaxy_notebook.ipynb --allow-errors  ./*.ipynb &&
+            #else:
+                jupyter lab --allow-root --no-browser --NotebookApp.shutdown_button=True &&
+            #end if
+            cp ./ipython_galaxy_notebook.ipynb '$jupyter_notebook'
+        #end if
+
+    ]]>
+    </command>
+    <inputs>
+
+        <conditional name="mode">
+            <param name="mode_select" type="select" label="Do you already have a notebook?" help="If not, no problem we will provide you with a default one.">
+                <option value="scratch">Start with a fresh notebook</option>
+                <option value="previous">Load a previous notebook</option>
+            </param>
+            <when value="scratch"/>
+            <when value="previous">
+                <param name="ipynb" type="data" format="ipynb" label="IPython Notebook"/>
+                <param name="run_it" type="boolean" truevalue="true" falsevalue="false" label="Execute notebook and return a new one."
+                    help="This option is useful in workflows when you just want to execute a notebook and not dive into the webfrontend."/>
+            </when>
+        </conditional>
+        <param name="input" type="data" optional="true" label="Include data into the environment"/>
+
+    </inputs>
+    <outputs>
+        <data name="jupyter_notebook" format="ipynb" label="Executed Pangeo Notebook"></data>
+    </outputs>
+    <tests>
+        <test expect_num_outputs="1">
+            <param name="mode" value="previous" />
+            <param name="ipynb" value="test.ipynb" />
+            <param name="run_it" value="true" />
+            <output name="jupyter_notebook" file="test.ipynb" ftype="ipynb"/>
+        </test>
+    </tests>
+    <help>
+    The Pangeo Notebook is based on Pangeo, an open and inclusive community platform for Big Data geoscience. 
+
+    Galaxy offers you to use Pangeo Notebooks directly in Galaxy accessing and interacting with Galaxy datasets as you like. A very common use-case is to
+    do the heavy lifting and data reduction steps in Galaxy and the plotting and more `interactive` part on smaller datasets in Jupyter.
+
+    You can start with a new Jupyter notebook from scratch or load an already existing one, e.g. from your collegue and execute it on your dataset.
+    If you have a defined input dataset you can even execute a Jupyter notebook in a workflow, given that the notebook is writing the output back to the history.
+
+    You can import data into the notebook via a predefined `get()` function and write results back to Galaxy with a `put()` function.
+
+    The Pangeo notebook is developed and maintained by the [Pangeo](https://pangeo.io/) community. 
+    A new version of Galaxy Pangeo JupyterLab is deployed whenever a new Pangeo notebook docker image is made available by the Pangeo community.
+    The list of packages is available at [Pangeo docker images](https://github.com/pangeo-data/pangeo-docker-images/tree/master/pangeo-notebook).
+
+    </help>
+</tool>


### PR DESCRIPTION
We have agreed with the [Pangeo Community](https://pangeo.io/) to deploy a standalone Pangeo notebook on Galaxy in sync with their Pangeo notebook (using the same base image) e.g. from https://github.com/pangeo-data/pangeo-docker-images/tree/master/pangeo-notebook (and ocrresponding docker Pangeo base image at https://hub.docker.com/r/pangeo/pangeo-notebook

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage; 
- [x] Instructions for manual testing are as follows:
  
```
docker run -p 7777:8888 quay.io/nordicesmhub/docker-pangeo-notebook:1c0f66b
```

The Galaxy Tool and docker are based on the current Galaxy Jupyter notebook interactive tool. Howver, I have not tried this tool on any Galaxy instances.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
