### PR TITLE
Large peptide IDs

### DIFF
--- a/config/plugins/visualizations/mvpapp/package.json
+++ b/config/plugins/visualizations/mvpapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mvpapp",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "keywords": [
     "galaxy",
     "visualization"

--- a/config/plugins/visualizations/mvpapp/src/index.js
+++ b/config/plugins/visualizations/mvpapp/src/index.js
@@ -329,7 +329,7 @@ function AjaxDataProvider(confObj) {
                     var obj = {};
                     cv.forEach(function (d, idx) {
                         var escapedField = '"' + cNames[idx] + '"';
-                        if (isNumber(d)) {
+                        if (isNumber(d) && cNames[idx] != 'PEPTIDE_ID') {
                             obj[escapedField] = Number.parseFloat(d);
                         } else {
                             obj[escapedField] = d;


### PR DESCRIPTION
Stores peptides IDs as strings.

This bugfix has already been included upstream for the 22.01 release.

Before this change, the `PEPTIDE_ID` field was parsed with `Number.parseFloat(d)`, but the string interpretation was larger than `Number.MAX_SAFE_INTEGER` and the ID was rounded to a less precise value. When these IDs were then used to query details for the peptides, they were no longer accurate and no matches were found. The result was that the `PSM Detail for Selected Peptides` table was left blank in the visualization.

Based on the discussion in #10136, I believe tests are not needed for this PR, but I've given a possible manual test below.

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. Produce a sqlite database via `mz to sqlite` in which peptide IDs are large enough that JavaScript rounds the representation, e.g. `Number.parseFloat("9999999999999999")` => `10000000000000000`.
  2. In the `MVP Application` visualization, select the appropriate peptides in `Peptide Overview` and click `PSMs for Selected Peptides`.
  3. Details for the selected peptides should populate the `PSM Detail for Selected Peptides` below.
