### PR TITLE
Update tool for cleaning files as I now clean it on the Docker image …

### DIFF
--- a/tools/interactive/interactivetool_audiolabeler.xml
+++ b/tools/interactive/interactivetool_audiolabeler.xml
@@ -11,11 +11,10 @@
     </entry_points>
     <command><![CDATA[
 
-        rm /opt/shiny-server/sample-apps/audio/www/tmp/* &&
         #import re
         #for $count, $file in enumerate($input):
             #set $cleaned_name = str($count + 1) + '_' + re.sub('[^\w\-\.\s]', '_', str($file.element_identifier))
-            ln -sf '$file' '/opt/shiny-server/sample-apps/audio/www/tmp/${cleaned_name}.${file.ext}'
+            ln -sf '$file' '/opt/shiny-server/samples/sample-apps/audio/www/tmp/${cleaned_name}.${file.ext}'
         #end for
 
     ]]>


### PR DESCRIPTION
…+ typo PATH

In fact on the PATH, i made a mistake, there is 2 PATH, `/srv/shiny-server/sample-apps/audio/www/tmp` and `/opt/shiny-server/samples/sample-apps/audio/www/tmp/` on the container and I was mixing both... Stupid me! These 2 PATHS seems to be symlink...

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
