### PR TITLE
chmod file so R Shiny app can work

### DIFF
--- a/tools/interactive/interactivetool_geoexplorer.xml
+++ b/tools/interactive/interactivetool_geoexplorer.xml
@@ -20,6 +20,8 @@
 
         mkdir -p /srv/shiny-server/data/ &&
         cp '$infile' /srv/shiny-server/data/inputdata.txt &&
+        chmod 777 /srv/shiny-server/data/inputdata.txt &&
+
         mkdir -p /var/log/shiny-server &&
         chown shiny.shiny /var/log/shiny-server &&
 


### PR DESCRIPTION
duno why but apparently with new Galaxy versions we need to chmod the input files of our R SHiny apps...

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
