### PR TITLE
[UPSTREAM] Fix validation issue for dataset_details

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -251,7 +251,7 @@ def parse_dataset_details(details: Optional[str]):
     can have from a string."""
     dataset_details: Optional[DatasetDetailsType] = None
     if details and details != "all":
-        dataset_details = set(util.listify(details))
+        dataset_details = util.listify(details)
     else:  # either None or 'all'
         dataset_details = details  # type: ignore
     return dataset_details

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -10,7 +10,6 @@ from typing import (
     Iterable,
     List,
     Optional,
-    Set,
     Union,
 )
 
@@ -125,7 +124,7 @@ from galaxy.webapps.galaxy.services.base import (
 
 log = logging.getLogger(__name__)
 
-DatasetDetailsType = Union[Set[EncodedDatabaseIdField], Literal["all"]]
+DatasetDetailsType = Union[List[EncodedDatabaseIdField], Literal["all"]]
 
 HistoryItemModel = Union[HistoryDatasetAssociation, HistoryDatasetCollectionAssociation]
 
@@ -1196,7 +1195,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
         dataset_details: Optional[DatasetDetailsType] = None,
     ):
         encoded_content_id = self.encode_id(content.id)
-        detailed = dataset_details and (dataset_details == "all" or (encoded_content_id in dataset_details))
+        detailed = dataset_details and (dataset_details == "all" or (encoded_content_id in set(dataset_details)))
         if isinstance(content, HistoryDatasetAssociation):
             view = "detailed" if detailed else "summary"
             return self.hda_serializer.serialize_to_view(content, view=view, user=trans.user, trans=trans)


### PR DESCRIPTION
This is an attempt to fix:

```
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]: [2022-08-03 10:44:54 +0200] [2514841] [ERROR] Exception in ASGI application
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]: Traceback (most recent call last):
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/uvicorn/protocols/http/h11_impl.py", line 366, in run_asgi
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     result = await app(self.scope, self.receive, self.send)
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/uvicorn/middleware/proxy_headers.py", line 75, in __call__
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     return await self.app(scope, receive, send)
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/fastapi/applications.py", line 269, in __call__
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     await super().__call__(scope, receive, send)
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/starlette/applications.py", line 124, in __call__
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     await self.middleware_stack(scope, receive, send)
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/starlette/middleware/errors.py", line 184, in __call__
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     raise exc
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/starlette/middleware/errors.py", line 162, in __call__
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     await self.app(scope, receive, _send)
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/starlette/middleware/base.py", line 68, in __call__
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     response = await self.dispatch_func(request, call_next)
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/server/lib/galaxy/webapps/base/api.py", line 28, in dispatch
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     return await call_next(request)
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/starlette/middleware/base.py", line 46, in call_next
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     raise app_exc
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/starlette/middleware/base.py", line 36, in coro
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     await self.app(scope, request.receive, send_stream.send)
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/starlette_context/middleware/raw_middleware.py", line 96, in __call__
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     await self.app(scope, receive, send_wrapper)
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/starlette/middleware/base.py", line 68, in __call__
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     response = await self.dispatch_func(request, call_next)
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/server/lib/galaxy/webapps/galaxy/fast_app.py", line 120, in add_send_file_header
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     response = await call_next(request)
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/starlette/middleware/base.py", line 46, in call_next
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     raise app_exc
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/starlette/middleware/base.py", line 36, in coro
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     await self.app(scope, request.receive, send_stream.send)
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/sentry_sdk/integrations/asgi.py", line 115, in _run_asgi3
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     return await self._run_app(scope, lambda: self.app(scope, receive, send))
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/sentry_sdk/integrations/asgi.py", line 162, in _run_app
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     raise exc from None
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/sentry_sdk/integrations/asgi.py", line 159, in _run_app
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     return await callback()
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/starlette/exceptions.py", line 93, in __call__
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     raise exc
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/starlette/exceptions.py", line 82, in __call__
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     await self.app(scope, receive, sender)
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     raise e
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     await self.app(scope, receive, send)
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/starlette/routing.py", line 670, in __call__
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     await route.handle(scope, receive, send)
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/starlette/routing.py", line 266, in handle
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     await self.app(scope, receive, send)
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/starlette/routing.py", line 65, in app
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     response = await func(request)
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/fastapi/routing.py", line 217, in app
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     solved_result = await solve_dependencies(
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/fastapi/dependencies/utils.py", line 531, in solve_dependencies
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     solved = await run_in_threadpool(call, **sub_values)
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/starlette/concurrency.py", line 41, in run_in_threadpool
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     return await anyio.to_thread.run_sync(func, *args)
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/anyio/to_thread.py", line 31, in run_sync
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     return await get_asynclib().run_sync_in_worker_thread(
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/anyio/_backends/_asyncio.py", line 937, in run_sync_in_worker_thread
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     return await future
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/venv/lib64/python3.8/site-packages/anyio/_backends/_asyncio.py", line 867, in run
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     result = context.run(func, *args)
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/server/lib/galaxy/webapps/galaxy/api/history_contents.py", line 140, in get_index_query_params
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     return parse_index_query_params(
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "/opt/galaxy/server/lib/galaxy/webapps/galaxy/api/history_contents.py", line 153, in parse_index_query_params
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:     return HistoryContentsIndexParams(
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]: pydantic.error_wrappers.ValidationError: 2 validation errors for HistoryContentsIndexParams
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]: dataset_details -> 1
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   Invalid characters in encoded ID (type=value_error)
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]: dataset_details
Aug 03 10:44:54 sn06.galaxyproject.eu gunicorn[2458098]:   unhashable type: 'set' (type=type_error)
```

This can be dropped once is merged upstream.