### PR TITLE
fix crash in history export

### DIFF
--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -356,7 +356,7 @@ class ModelManager(Generic[U]):
         """
         Gets a model by primary id.
         """
-        id_filter = self.model_class.table.c.id == id
+        id_filter = self.model_class.id == id
         return self.one(filters=id_filter)
 
     # .... multirow queries


### PR DESCRIPTION
Traceback (most recent call last):
  File "/opt/galaxy/venv/lib64/python3.8/site-packages/celery/app/trace.py", line 451, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/opt/galaxy/venv/lib64/python3.8/site-packages/celery/app/trace.py", line 734, in __protected_call__
    return self.run(*args, **kwargs)
  File "/opt/galaxy/server/lib/galaxy/celery/__init__.py", line 163, in wrapper
    rval = app.magic_partial(func)(*args, **kwds)
  File "/opt/galaxy/venv/lib64/python3.8/site-packages/lagom/wrapping.py", line 28, in _bound_func
    return inner_func(*bound_args, **bound_kwargs)
  File "/opt/galaxy/venv/lib64/python3.8/site-packages/lagom/wrapping.py", line 45, in _error_handling_func
    return func(*args, **kwargs)
  File "/opt/galaxy/server/lib/galaxy/celery/tasks.py", line 302, in prepare_history_download
    model_store_manager.prepare_history_download(request)
  File "/opt/galaxy/server/lib/galaxy/managers/model_stores.py", line 108, in prepare_history_download
    history = self._history_manager.by_id(request.history_id)
  File "/opt/galaxy/server/lib/galaxy/managers/base.py", line 359, in by_id
    id_filter = self.model_class.table.c.id == id
AttributeError: type object 'History' has no attribute 'table'

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
