### PR TITLE
[EU] make container tracking more resilent

### DIFF
--- a/lib/galaxy/job_execution/container_monitor.py
+++ b/lib/galaxy/job_execution/container_monitor.py
@@ -74,7 +74,10 @@ def main():
                         if ports[key]["host"] == "0.0.0.0":
                             ports[key]["host"] = host_ip
                 if callback_url:
-                    requests.post(callback_url, json={"container_runtime": ports}, timeout=DEFAULT_SOCKET_TIMEOUT)
+                    x = requests.post(callback_url, json={"container_runtime": ports}, timeout=DEFAULT_SOCKET_TIMEOUT)
+                    if x.status_code != 200:
+                        time.sleep(i * 2)
+                        continue
                 else:
                     with open("container_runtime.json", "w") as f:
                         json.dump(ports, f)


### PR DESCRIPTION
It happened that we got a 403 from the API. Trying a few times yields a 200. We do not know yet, why this is happening

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
