### PR TITLE
Add hdf4 support to hdfview tool

### DIFF
--- a/tools/interactive/interactivetool_hdfview.xml
+++ b/tools/interactive/interactivetool_hdfview.xml
@@ -18,7 +18,7 @@
         ]]>
     </command>
     <inputs>
-        <param name="infile" type="data" format="netcdf,h5" label="HDF file"/>
+        <param name="infile" type="data" format="netcdf,h5,hdf4" label="HDF file"/>
     </inputs>
     <outputs>
         <data name="outfile" format="txt" />


### PR DESCRIPTION
Now that hdf4 is listed among datatypes in galaxy (see https://github.com/galaxyproject/galaxy/pull/16105), the hdfview tool should include hdf4 in its supported input formats.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
