### PR TITLE
Updated jupyter ML interactive tool

### DIFF
--- a/tools/interactive/interactivetool_ml_jupyter_notebook.xml
+++ b/tools/interactive/interactivetool_ml_jupyter_notebook.xml
@@ -97,7 +97,10 @@ except FileNotFoundError:
         export HOME=/home/\$NB_USER/ &&
         export PATH=/home/\$NB_USER/.local/bin:\$PATH &&
         cp '${galaxy_input_startup_script}' /home/\$NB_USER/.ipython/profile_default/startup/02-load.py &&
+
+        ## Disable popups informing that "a new release is available"
         jupyter labextension disable "@jupyterlab/apputils-extension:announcements" &&
+
         #set $output_notebook_name = 'jupyterlab_notebook.ipynb'
         #if $mode.mode_select == 'scratch':
             cp -r /home/\$NB_USER/data ./ &&

--- a/tools/interactive/interactivetool_ml_jupyter_notebook.xml
+++ b/tools/interactive/interactivetool_ml_jupyter_notebook.xml
@@ -1,9 +1,9 @@
-<tool id="interactive_tool_ml_jupyter_notebook" tool_type="interactive" name="GPU enabled Interactive Jupyter Notebook for Machine Learning" version="@VERSION@" profile="22.01">
+<tool id="interactive_tool_ml_jupyter_notebook" tool_type="interactive" name="GPU-enabled Interactive Jupyter Notebook for Machine Learning" version="@VERSION@" profile="22.01">
     <macros>
-        <token name="@VERSION@">0.2</token>
+        <token name="@VERSION@">0.3</token>
     </macros>
     <requirements>
-        <container type="docker">docker.io/anupkumar/docker-ml-jupyterlab:galaxy-integration-@VERSION@</container>
+        <container type="docker">docker.io/ktunc/docker-ml-jupyterlab:galaxy-integration-@VERSION@</container>
     </requirements>
     <entry_points>
         <entry_point name="GPU enabled Interactive Jupyter Notebook for Machine Learning" requires_domain="True">
@@ -80,6 +80,15 @@ except FileNotFoundError:
     </configfiles>
     
     <command><![CDATA[
+        ## Check if the node has GPU. Activate CPU or GPU version of tensorflow
+        if nvidia-smi 2> /dev/null; then
+            echo An NVDIA GPU was detected. ;
+            ln -s \$PYTHON_LIB_PATH/tensorflow-GPU-cached \$PYTHON_LIB_PATH/tensorflow ;
+        else
+            echo No compatible GPU present. ;
+            ln -s \$PYTHON_LIB_PATH/tensorflow-CPU-cached \$PYTHON_LIB_PATH/tensorflow ;
+        fi &&
+
         python staging_script.py &&
         export GALAXY_WORKING_DIR=`pwd` &&
         mkdir -p ./jupyter/outputs &&
@@ -88,6 +97,7 @@ except FileNotFoundError:
         export HOME=/home/\$NB_USER/ &&
         export PATH=/home/\$NB_USER/.local/bin:\$PATH &&
         cp '${galaxy_input_startup_script}' /home/\$NB_USER/.ipython/profile_default/startup/02-load.py &&
+        jupyter labextension disable "@jupyterlab/apputils-extension:announcements" &&
         #set $output_notebook_name = 'jupyterlab_notebook.ipynb'
         #if $mode.mode_select == 'scratch':
             cp -r /home/\$NB_USER/data ./ &&

--- a/tools/interactive/interactivetool_ml_jupyter_notebook.xml
+++ b/tools/interactive/interactivetool_ml_jupyter_notebook.xml
@@ -3,7 +3,7 @@
         <token name="@VERSION@">0.3</token>
     </macros>
     <requirements>
-        <container type="docker">docker.io/ktunc/docker-ml-jupyterlab:galaxy-integration-@VERSION@</container>
+        <container type="docker">quay.io/galaxy/docker-ml-jupyterlab:galaxy-integration-@VERSION@</container>
     </requirements>
     <entry_points>
         <entry_point name="GPU enabled Interactive Jupyter Notebook for Machine Learning" requires_domain="True">


### PR DESCRIPTION
Some ML tasks fail because of old library versions. Updated the versions of the tools contained within the container at https://github.com/usegalaxy-eu/gpu-jupyterlab-docker/pull/2. This PR is necessary to switch to this new container.

For more portability, the container has both CPU and GPU versions of tensorflow installed, and we choose based on presence/absence of GPU during initialization. 


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
