### PR TITLE
Fix parsing tool metadata from bio.tools

### DIFF
--- a/lib/galaxy/tool_util/biotools/interface.py
+++ b/lib/galaxy/tool_util/biotools/interface.py
@@ -21,8 +21,8 @@ class BiotoolsEntry:
     def from_json(from_json: Dict[str, Any]) -> 'BiotoolsEntry':
         entry = BiotoolsEntry()
         entry.biotoolsID = from_json["biotoolsID"]
-        entry.topic = from_json.get("topic", [{}])
-        entry.function = from_json.get("function", [{}])
+        entry.topic = from_json.get("topic", [])
+        entry.function = from_json.get("function", [])
         return entry
 
     @property

--- a/lib/galaxy/tool_util/biotools/interface.py
+++ b/lib/galaxy/tool_util/biotools/interface.py
@@ -21,8 +21,8 @@ class BiotoolsEntry:
     def from_json(from_json: Dict[str, Any]) -> 'BiotoolsEntry':
         entry = BiotoolsEntry()
         entry.biotoolsID = from_json["biotoolsID"]
-        entry.topic = from_json["topic"]
-        entry.function = from_json["function"]
+        entry.topic = from_json.get("topic", [{}])
+        entry.function = from_json.get("function", [{}])
         return entry
 
     @property


### PR DESCRIPTION
Parsing bio.tools data for tool metadata is broken, ~~probably because of [research-software-ecosystem/content#fd9ed50](https://github.com/research-software-ecosystem/content/commit/fd9ed504b2a8b403f8df43262254f080f868ed1f) or [research-software-ecosystem/content#7b40d92](https://github.com/research-software-ecosystem/content/commit/7b40d92c30c924862a5048e55f2189d3d4f476f8)~~ (sorry, we are [using this feature just since last night](https://github.com/usegalaxy-eu/infrastructure-playbook/compare/master%40%7B2023-07-23%7D...master%40%7B2023-07-24%7D)). The keys "function" and "topic" do not exist any longer for many tools. Thus, such tools fail to load.

- Sample Sentry error report from [usegalaxy.eu](https://usegalaxy.eu/) (key "function" missing):
https://sentry.galaxyproject.org/organizations/galaxy/issues/123152/events/291df96a5e694baa978051863bb16e51/
> [...]
> Error reading tool from path: toolshed.g2.bx.psu.edu/repos/devteam/get_flanks/077f404ae1bb/get_flanks/get_flanks.xml
> [...]
> exception KeyError: 'function'

- Sample Sentry error report from [usegalaxy.eu](https://usegalaxy.eu/) (key "topic" missing): https://sentry.galaxyproject.org/organizations/galaxy/issues/123151/events/9156051efa734ae09f7643d86fa54ac6/
> [...]
> Error reading tool from path: toolshed.g2.bx.psu.edu/repos/iuc/b2btools_single_sequence/b694a77ca1e8/b2btools_single_sequence/b2btools_single_sequence.xml
> [...]
> exception KeyError: 'topic'


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

I am skipping this section and leaving the test coverage to the upstream, since unfortunately we had to test the changes in production to get things working again as fast as possible.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).

---

I will open an upstream issue and link to this PR. This PR's branch is based on the commit that introduced the error, so **the branch can be merged all the way back to Galaxy 21.09** without polluting the commit history.