### PR TITLE
Log errors occurring while refreshing user tokens as debug messages

### DIFF
--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -332,7 +332,7 @@ class AuthnzManager:
             return True
         except Exception as e:
             msg = f"An error occurred when refreshing user token: {e}"
-            log.error(msg)
+            log.debug(msg)
             return False
 
     def refresh_expiring_oidc_tokens(self, trans, user=None):


### PR DESCRIPTION
This is a solution suggested by @nuwang to avoid spamming Sentry with events related to python-social-auth/social-core#826.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
