### PR TITLE
Add outputs from jupyter

### DIFF
--- a/tools/interactive/interactivetool_divand.xml
+++ b/tools/interactive/interactivetool_divand.xml
@@ -79,6 +79,9 @@
     </inputs>
     <outputs>
         <data name="jupyter_notebook" format="ipynb" label="Executed DIVAnd Notebook"></data>
+        <collection name="output_collection" type="list" label="GPU JupyterLab notebook output collection">
+            <discover_datasets pattern="__designation_and_ext__" directory="jupyter/outputs" visible="true"/>
+        </collection>
     </outputs>
     <tests>
         <test expect_num_outputs="1">


### PR DESCRIPTION
Allow what is in the folder outputs of the jupyterlab to be on galaxy history to create a workflow.