### PR TITLE
Add support for prefixing calls to HTCondor binaries to the HTCondor runner

### DIFF
--- a/doc/source/admin/cluster.md
+++ b/doc/source/admin/cluster.md
@@ -192,7 +192,8 @@ The value of *ppn=* is used by PBS to define the environment variable `$PBS_NCPU
 
 ### Condor
 
-Runs jobs via the [HTCondor](https://research.cs.wisc.edu/htcondor/) DRM.  There are no configurable parameters.  Galaxy's interface is via calls to HTCondor's command line tools, rather than via an API.
+Runs jobs via the [HTCondor](https://research.cs.wisc.edu/htcondor/) DRM. Galaxy interfaces with HTCondor via calls to
+HTCondor's command line tools, rather than via an API.
 
 ```xml
 <plugins>
@@ -203,7 +204,9 @@ Runs jobs via the [HTCondor](https://research.cs.wisc.edu/htcondor/) DRM.  There
 </destinations>
 ```
 
-Galaxy will submit jobs to HTCondor as the "galaxy" user (or whatever user the Galaxy server runs as).  In order for vanilla job execution to work as expected, your cluster should be configured with a common UID_DOMAIN to allow Galaxy's jobs to run as "galaxy" everywhere (instead of "nobody").
+Galaxy will submit jobs to HTCondor as the "galaxy" user (or whatever user the Galaxy server runs as).  In order for
+vanilla job execution to work as expected, your cluster should be configured with a common UID_DOMAIN to allow Galaxy's
+jobs to run as "galaxy" everywhere (instead of "nobody").
 
 If you need to add additional parameters to your condor submission, you can do so by supplying `<param/>`s:
 
@@ -215,6 +218,20 @@ If you need to add additional parameters to your condor submission, you can do s
     </destination>
 </destinations>
 ```
+
+The runner accepts the following optional parameters.
+
+``prefix``
+: A string that will be to prepended to HTCondor command line tool invocations. Defaults to an empty string.
+
+``condor_rm_cmd``
+: Command to invoke for stopping jobs. Defaults to "condor_rm".
+
+``condor_ssh_to_job_cmd``
+: Command to invoke to execute other commands in a worker node. Defaults to "condor_ssh_to_job".
+
+``condor_submit_cmd``
+: Command to invoke for submitting jobs. Defaults to "condor_submit".
 
 ### Pulsar
 

--- a/doc/source/admin/cluster.md
+++ b/doc/source/admin/cluster.md
@@ -222,7 +222,9 @@ If you need to add additional parameters to your condor submission, you can do s
 The runner accepts the following optional parameters.
 
 ``prefix``
-: A string that will be to prepended to HTCondor command line tool invocations. Defaults to an empty string.
+: A string that will be to prepended to HTCondor command line tool invocations. Defaults to an empty string. Note that
+  the runner **does not include a space** between the prefix and the command, so most likely you want to add a space
+  a the end of your `prefix`.
 
 ``condor_rm_cmd``
 : Command to invoke for stopping jobs. Defaults to "condor_rm".

--- a/lib/galaxy/jobs/runners/condor.py
+++ b/lib/galaxy/jobs/runners/condor.py
@@ -54,9 +54,18 @@ class CondorJobRunner(AsynchronousJobRunner):
 
     def __init__(self, app, nworkers, **kwargs):
         """Start the job runner."""
-        kwargs["runner_param_specs"] = kwargs.get("runner_param_specs", dict())
+        runner_param_specs = {
+            "prefix": dict(map=str, default=""),
+            # String to prepend to HTCondor command line tool invocations. Defaults to an empty string.
+            "condor_rm_cmd": dict(map=str, default="condor_rm"),
+            # Command to invoke for stopping jobs. Defaults to "condor_rm".
+            "condor_ssh_to_job_cmd": dict(map=str, default="condor_ssh_to_job"),
+            # Command to invoke to execute commands in a worker node. Defaults to "condor_ssh_to_job".
+            "condor_submit_cmd": dict(map=str, default="condor_submit"),
+            # Command to invoke for submitting jobs. Defaults to "condor_submit".
+        }
 
-        runner_param_specs = {"prefix": dict(map=str, default=None)}
+        kwargs["runner_param_specs"] = kwargs.get("runner_param_specs", dict())
         kwargs["runner_param_specs"].update(runner_param_specs)
 
         super().__init__(app, nworkers, **kwargs)
@@ -143,7 +152,9 @@ class CondorJobRunner(AsynchronousJobRunner):
 
         log.debug(f"({galaxy_id_tag}) submitting file {executable}")
 
-        external_job_id, message = condor_submit(submit_file, prefix=self.runner_params.get("prefix"))
+        external_job_id, message = condor_submit(
+            submit_file, prefix=self.runner_params.get("prefix"), command=self.runner_params.get("condor_submit_cmd")
+        )
         if external_job_id is None:
             log.debug(f"condor_submit failed for job {job_wrapper.get_id_tag()}: {message}")
             if self.app.config.cleanup_job == "always":
@@ -261,11 +272,17 @@ class CondorJobRunner(AsynchronousJobRunner):
                     self._kill_container(job_wrapper)
                 except Exception as e:
                     log.warning(f"stop_job(): {job.id}: trying to kill container failed. ({e})")
-                    failure_message = condor_stop(external_id, prefix=self.runner_params.get("prefix"))
+                    failure_message = condor_stop(
+                        external_id,
+                        prefix=self.runner_params.get("prefix"),
+                        command=self.runner_params.get("condor_rm_cmd"),
+                    )
                     if failure_message:
                         log.debug(f"({external_id}). Failed to stop condor {failure_message}")
         else:
-            failure_message = condor_stop(external_id, prefix=self.runner_params.get("prefix"))
+            failure_message = condor_stop(
+                external_id, prefix=self.runner_params.get("prefix"), command=self.runner_params.get("condor_rm_cmd")
+            )
             if failure_message:
                 log.debug(f"({external_id}). Failed to stop condor {failure_message}")
 
@@ -311,7 +328,10 @@ class CondorJobRunner(AsynchronousJobRunner):
                     return self._run_command(cont.container_info["commands"][command], external_id)[0]
 
     def _run_command(self, command, external_job_id):
-        command = f"{self.runner_params.get('prefix', '')}condor_ssh_to_job {external_job_id} {command}"
+        command = (
+            f"{self.runner_params.get('prefix', '')}"
+            f"{self.runner_params.get('condor_ssh_to_job_cmd')} {external_job_id} {command}"
+        )
 
         p = subprocess.Popen(
             command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, close_fds=True, preexec_fn=os.setpgrp

--- a/lib/galaxy/jobs/runners/util/condor/__init__.py
+++ b/lib/galaxy/jobs/runners/util/condor/__init__.py
@@ -70,11 +70,11 @@ def build_submit_description(executable, output, error, user_log, query_params):
 
 def condor_submit(submit_file, prefix: Optional[str] = None, command: Optional[str] = None):
     """
-    Submit a condor job described by the given file. Parse an external id for
-    the submission or return None and a reason for the failure.
+    Submit a condor job described by the given file. Parse an external id for the submission or return None and a reason
+    for the failure.
 
-    Optionally, specify a prefix to prepend to the `condor_submit` call (for
-    example, to call a binary on a specific path).
+    Optionally, specify a prefix to prepend to the `condor_submit` call (for example, to call a binary on a specific
+    path), or override the command used to submit jobs.
     """
     prefix = prefix or ""
     command = command or "condor_submit"
@@ -95,11 +95,10 @@ def condor_submit(submit_file, prefix: Optional[str] = None, command: Optional[s
 
 def condor_stop(external_id, prefix: Optional[str] = None, command: Optional[str] = None):
     """
-    Stop running condor job and return a failure_message if this
-    fails.
+    Stop running condor job and return a failure_message if this fails.
 
-    Optionally, specify a prefix to prepend to the `condor_rm` call (for
-    example, to call a binary on a specific path).
+    Optionally, specify a prefix to prepend to the `condor_rm` call (for example, to call a binary on a specific path),
+    or override the command used to stop jobs.
     """
     prefix = prefix or ""
     command = command or "condor_rm"

--- a/lib/galaxy/jobs/runners/util/condor/__init__.py
+++ b/lib/galaxy/jobs/runners/util/condor/__init__.py
@@ -68,7 +68,7 @@ def build_submit_description(executable, output, error, user_log, query_params):
     return "\n".join(submit_description)
 
 
-def condor_submit(submit_file, prefix: Optional[str] = None):
+def condor_submit(submit_file, prefix: Optional[str] = None, command: Optional[str] = None):
     """
     Submit a condor job described by the given file. Parse an external id for
     the submission or return None and a reason for the failure.
@@ -76,10 +76,13 @@ def condor_submit(submit_file, prefix: Optional[str] = None):
     Optionally, specify a prefix to prepend to the `condor_submit` call (for
     example, to call a binary on a specific path).
     """
+    prefix = prefix or ""
+    command = command or "condor_submit"
+
     external_id = None
     failure_message = None
     try:
-        condor_message = commands.execute(((prefix or "") + "condor_submit", submit_file))
+        condor_message = commands.execute(f"{prefix}{command} {submit_file}", shell=True)
     except commands.CommandLineException as e:
         failure_message = unicodify(e)
     else:
@@ -90,7 +93,7 @@ def condor_submit(submit_file, prefix: Optional[str] = None):
     return external_id, failure_message
 
 
-def condor_stop(external_id, prefix: Optional[str] = None):
+def condor_stop(external_id, prefix: Optional[str] = None, command: Optional[str] = None):
     """
     Stop running condor job and return a failure_message if this
     fails.
@@ -98,9 +101,12 @@ def condor_stop(external_id, prefix: Optional[str] = None):
     Optionally, specify a prefix to prepend to the `condor_rm` call (for
     example, to call a binary on a specific path).
     """
+    prefix = prefix or ""
+    command = command or "condor_rm"
+
     failure_message = None
     try:
-        check_call(((prefix or "") + "condor_rm", external_id))
+        check_call(f"{prefix}{command} {external_id}", shell=True)
     except CalledProcessError:
         failure_message = "condor_rm failed"
     except Exception as e:

--- a/lib/galaxy/util/commands.py
+++ b/lib/galaxy/util/commands.py
@@ -95,13 +95,13 @@ def shell_process(
     return p
 
 
-def execute(cmds, input=None):
+def execute(cmds, input=None, shell=False):
     """Execute commands and throw an exception on a non-zero exit.
     if input is not None then the string is sent to the process' stdin.
 
     Return the standard output if the commands are successful
     """
-    return _wait(cmds, input=input, shell=False, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    return _wait(cmds, input=input, shell=shell, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
 
 def argv_to_str(command_argv, quote=True):


### PR DESCRIPTION
This PR is meant to be used for the HTCondor migration. It defines an optional parameter `prefix` for the HTCondor job runner that prepends the parameter value to all calls to HTCondor binaries, such as `condor_submit`, `condor_rm` or `condor_ssh_to_job`.

This enables having two HTCondor runners defined in the Galaxy job configuration file, with each one calling different executable files and thus allowing to route jobs to two different HTCondor clusters.

The shortcoming of this approach is that the contents of `prefix` are constrained to strings that, when prepended to the `condor_*` commands, still point to an executable (i.e. no shell commands). Thus, such executable files need to be created and placed somewhere. A minimal example is available [here](https://github.com/sanjaysrikakulam/esg_wp4_galaxy/compare/15f239fc47140b9f65e80b7fefd4500c8fc38e2c...kysrpex:sanjaysrikakulam-esg_wp4_galaxy:6d987e36b322c21fdabc6a15ea0695e793002e0e). This constraint exists because of how Galaxy calls the [`subprocess.Popen` constructor](https://docs.python.org/3.7/library/subprocess.html#subprocess.Popen) (using `shell=False`).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [X] Instructions for manual testing are as follows:
  1. See [this minimal example](https://github.com/sanjaysrikakulam/esg_wp4_galaxy/compare/15f239fc47140b9f65e80b7fefd4500c8fc38e2c...kysrpex:sanjaysrikakulam-esg_wp4_galaxy:6d987e36b322c21fdabc6a15ea0695e793002e0e).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
