### PR TITLE
Update interactivetool_ml_jupyter_notebook.xml tool's version to 0.4

### DIFF
--- a/tools/interactive/interactivetool_ml_jupyter_notebook.xml
+++ b/tools/interactive/interactivetool_ml_jupyter_notebook.xml
@@ -1,6 +1,6 @@
 <tool id="interactive_tool_ml_jupyter_notebook" tool_type="interactive" name="GPU-enabled Interactive Jupyter Notebook for Machine Learning" version="@VERSION@" profile="22.01">
     <macros>
-        <token name="@VERSION@">0.3</token>
+        <token name="@VERSION@">0.4</token>
     </macros>
     <requirements>
         <container type="docker">quay.io/galaxy/docker-ml-jupyterlab:galaxy-integration-@VERSION@</container>


### PR DESCRIPTION
The associated Docker's new version has been published (https://quay.io/repository/galaxy/docker-ml-jupyterlab?tab=tags)

ping @bgruening thanks
