### PR TITLE
New version of interactivetool_wallace.xml

### DIFF
--- a/tools/interactive/interactivetool_wallace.xml
+++ b/tools/interactive/interactivetool_wallace.xml
@@ -1,7 +1,7 @@
-<tool id="interactive_tool_wallace" tool_type="interactive" name="Wallace" version="0.1">
+<tool id="interactive_tool_wallace" tool_type="interactive" name="Wallace" version="2.1.1">
     <description>Webbased Interactive modeling of species niches and distributions</description>
     <requirements>
-        <container type="docker">ylebras/wallace-docker</container>
+        <container type="docker">ylebras/wallace:2.1.1</container>
     </requirements>
     <entry_points>
         <entry_point name="Wallace visualisation" requires_domain="True">

--- a/tools/interactive/interactivetool_wallace.xml
+++ b/tools/interactive/interactivetool_wallace.xml
@@ -19,7 +19,9 @@
     </environment_variables>
     <command><![CDATA[
 
-        /usr/bin/shiny-server.sh
+        chown shiny.shiny /var/log/shiny-server &&
+
+        exec shiny-server >> /var/log/shiny-server.log 2>&1
 
     ]]>
     </command>


### PR DESCRIPTION
New version to have the last Wallace app and also because old version was crashing apparenlty. HEre I just initialize the last version but not reintegrate all the work done on the previous one to interact with Galaxy through ie-helper to import and export data from the app. Will see this in the future

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
