### PR TITLE
Extension fix

### DIFF
--- a/tools/interactive/interactivetool_copernicus.xml
+++ b/tools/interactive/interactivetool_copernicus.xml
@@ -50,7 +50,11 @@
 
             ## provide all rights to copied files
             jupyter lab --allow-root --no-browser &&
-            cp ./*.ipynb '$jupyter_notebook'
+            cp ./*.ipynb '$jupyter_notebook' &&
+            
+            cd outputs/ &&
+            sleep 2 &&
+            for file in *; do mv "\$file" "\$file.\${file\#\#*.}"; done
         #else
             #set $noteboook_name = re.sub('[^\w\-\.\s]', '_', str($mode.ipynb.element_identifier))
             cp '$mode.ipynb' './${noteboook_name}.ipynb' &&
@@ -61,7 +65,11 @@
             #else
                 jupyter lab --allow-root --no-browser --NotebookApp.shutdown_button=True &&
             #end if
-            cp './${noteboook_name}.ipynb' '$jupyter_notebook'
+            cp './${noteboook_name}.ipynb' '$jupyter_notebook' &&
+            
+            cd outputs/ &&
+            sleep 2 &&
+            for file in *; do mv "\$file" "\$file.\${file\#\#*.}"; done
         #end if
     ]]>
     </command>

--- a/tools/interactive/interactivetool_copernicus.xml
+++ b/tools/interactive/interactivetool_copernicus.xml
@@ -31,7 +31,7 @@
 
         #for $count, $file in enumerate($input):
             #set $cleaned_name = str($count + 1) + '_' + re.sub('[^\w\-\.\s]', '_', str($file.element_identifier))
-            ln -sf '$file' './jupyter/data/${cleaned_name}.${file.ext}' &&
+            ln -sf '$file' './jupyter/data/${cleaned_name}' &&
         #end for
 
         ## change into the directory where the notebooks are located

--- a/tools/interactive/interactivetool_divand.xml
+++ b/tools/interactive/interactivetool_divand.xml
@@ -47,7 +47,11 @@
 
             ## provide all rights to copied files
             jupyter lab --allow-root --no-browser &&
-            cp ./*.ipynb '$jupyter_notebook'
+            cp ./*.ipynb '$jupyter_notebook' &&
+            
+            cd outputs/ &&
+            sleep 2 &&
+            for file in *; do mv "\$file" "\$file.\${file\#\#*.}"; done
         #else
             #set $noteboook_name = re.sub('[^\w\-\.\s]', '_', str($mode.ipynb.element_identifier))
             cp '$mode.ipynb' './${noteboook_name}.ipynb' &&
@@ -58,7 +62,11 @@
             #else
                 jupyter lab --allow-root --no-browser --NotebookApp.shutdown_button=True &&
             #end if
-            cp './${noteboook_name}.ipynb' '$jupyter_notebook'
+            cp './${noteboook_name}.ipynb' '$jupyter_notebook' &&
+            
+            cd outputs/ &&
+            sleep 2 &&
+            for file in *; do mv "\$file" "\$file.\${file\#\#*.}"; done
         #end if
     ]]>
     </command>
@@ -79,9 +87,12 @@
 
     </inputs>
     <outputs>
-        <data name="jupyter_notebook" format="ipynb" label="Executed DIVAnd Notebook"></data>
-        <collection name="output_collection" type="list" label="GPU JupyterLab notebook output collection">
-            <discover_datasets pattern="__designation_and_ext__" directory="jupyter/outputs" visible="true"/>
+        <data name="jupyter_notebook" format="ipynb" label="Executed DIVAnd Notebook"/>
+        <collection name="output_netcdf" type="list" label="DIVAnd netcdf outputs">
+            <discover_datasets pattern="(?P&lt;designation&gt;.+)\.nc" directory="jupyter/outputs" format="netcdf"/>
+        </collection>
+        <collection name="output_all" type="list" label="DIVAnd all outputs">
+            <discover_datasets pattern="__designation_and_ext__" directory="jupyter/outputs"/>
         </collection>
     </outputs>
     <tests>

--- a/tools/interactive/interactivetool_divand.xml
+++ b/tools/interactive/interactivetool_divand.xml
@@ -29,7 +29,7 @@
         #if $input:
             #for $count, $file in enumerate($input):
                 #set $cleaned_name = str($count + 1) + '_' + re.sub('[^\w\-\.\s]', '_', str($file.element_identifier))
-                ln -sf '$file' './jupyter/data/${cleaned_name}.${file.ext}' &&
+                ln -sf '$file' './jupyter/data/${cleaned_name}' &&
             #end for
         #end if
 

--- a/tools/interactive/interactivetool_holoviz.xml
+++ b/tools/interactive/interactivetool_holoviz.xml
@@ -30,7 +30,7 @@
 
         #for $count, $file in enumerate($input):
             #set $cleaned_name = str($count + 1) + '_' + re.sub('[^\w\-\.\s]', '_', str($file.element_identifier))
-            ln -sf '$file' './jupyter/data/${cleaned_name}.${file.ext}' &&
+            ln -sf '$file' './jupyter/data/${cleaned_name}' &&
         #end for
 
         ## change into the directory where the notebooks are located

--- a/tools/interactive/interactivetool_holoviz.xml
+++ b/tools/interactive/interactivetool_holoviz.xml
@@ -48,7 +48,10 @@
 
             ## provide all rights to copied files
             jupyter lab --allow-root --no-browser &&
-            cp ./*.ipynb '$jupyter_notebook'
+            cp ./*.ipynb '$jupyter_notebook' &&
+            cd outputs/ &&
+            sleep 2 &&
+            for file in *; do mv "\$file" "\$file.\${file\#\#*.}"; done
         #else
             #set $noteboook_name = re.sub('[^\w\-\.\s]', '_', str($mode.ipynb.element_identifier))
             cp '$mode.ipynb' './${noteboook_name}.ipynb' &&
@@ -59,7 +62,10 @@
             #else
                 jupyter lab --allow-root --no-browser --NotebookApp.shutdown_button=True &&
             #end if
-            cp './${noteboook_name}.ipynb' '$jupyter_notebook'
+            cp './${noteboook_name}.ipynb' '$jupyter_notebook' &&
+            cd outputs/ &&
+            sleep 2 &&
+            for file in *; do mv "\$file" "\$file.\${file\#\#*.}"; done
         #end if
     ]]>
     </command>

--- a/tools/interactive/interactivetool_odv.xml
+++ b/tools/interactive/interactivetool_odv.xml
@@ -34,7 +34,10 @@
         #end if
         /init ;
         mv ./Documents/ODV/galaxy/outputs/ ./output &&        
-        rm ./Documents -rf
+        rm ./Documents -rf &&
+        cd ./output &&
+        sleep 2 &&
+        for file in *; do mv "\$file" "\$file.\${file\#\#*.}"; done
     ]]>
     </command>
     <inputs>
@@ -52,9 +55,11 @@
         </conditional>
     </inputs>
     <outputs>
-        <!--data name="version" format="txt" label="${tool.name} on ${on_string}: version.txt" from_work_dir="version.txt" /-->
-        <collection name="outputs" type="list" label="ODV outputs">
-            <discover_datasets pattern="__name_and_ext__" directory="./output" visible="true"/>
+        <collection name="outputs_netcdf" type="list" label="ODV netcdf outputs">
+            <discover_datasets pattern="(?P&lt;designation&gt;.+)\.nc" directory="./output" format="netcdf"/>
+        </collection>
+        <collection name="outputs_all" type="list" label="ODV all outputs">
+            <discover_datasets pattern="__designation_and_ext__" directory="./output"/>
         </collection>
     </outputs>
     <tests>

--- a/tools/interactive/interactivetool_source.xml
+++ b/tools/interactive/interactivetool_source.xml
@@ -45,7 +45,10 @@
 
             ## provide all rights to copied files
             jupyter lab --allow-root --no-browser &&
-            cp ./*.ipynb '$jupyter_notebook'
+            cp ./*.ipynb '$jupyter_notebook' &&
+            cd outputs/ &&
+            sleep 2 &&
+            for file in *; do mv "\$file" "\$file.\${file\#\#*.}"; done
         #else
             #set $noteboook_name = re.sub('[^\w\-\.\s]', '_', str($mode.ipynb.element_identifier))
             cp '$mode.ipynb' './${noteboook_name}.ipynb' &&
@@ -56,7 +59,10 @@
             #else
                 jupyter lab --allow-root --no-browser --NotebookApp.shutdown_button=True &&
             #end if
-            cp './${noteboook_name}.ipynb' '$jupyter_notebook'
+            cp './${noteboook_name}.ipynb' '$jupyter_notebook' &&
+            cd outputs/ &&
+            sleep 2 &&
+            for file in *; do mv "\$file" "\$file.\${file\#\#*.}"; done
         #end if
     ]]>
     </command>

--- a/tools/interactive/interactivetool_source.xml
+++ b/tools/interactive/interactivetool_source.xml
@@ -29,7 +29,7 @@
 
         #for $count, $file in enumerate($input):
             #set $cleaned_name = str($count + 1) + '_' + re.sub('[^\w\-\.\s]', '_', str($file.element_identifier))
-            ln -sf '$file' './jupyter/data/${cleaned_name}.${file.ext}' &&
+            ln -sf '$file' './jupyter/data/${cleaned_name}' &&
         #end for
 
         ## change into the directory where the notebooks are located


### PR DESCRIPTION
Hello hello,
I added multiple fixes to get the extension of the outputs in interactive tools. Plus I modified the outputs of ODV and Divand to make an easier workflow. 
During this I noticed that Galaxy does not associate the extension .nc with the datatype netcdf. I'd like to change that. Do you think it's possible ?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
