### PR TITLE
TEMP: pin tensorflow to latest non-breaking version for Python 3.11

### DIFF
--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -48,7 +48,7 @@ pygithub
 influxdb
 
 # Deep learning packages for tool recommendation
-tensorflow
+tensorflow==2.15.1
 
 # weasyprint has problematic requirements (cairo, Pango, see:
 # https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#linux)


### PR DESCRIPTION
Drop this after is correctly pinned upstream
