### PR TITLE
Update interactivetool_ml_jupyter_notebook.xml

### DIFF
--- a/tools/interactive/interactivetool_ml_jupyter_notebook.xml
+++ b/tools/interactive/interactivetool_ml_jupyter_notebook.xml
@@ -109,7 +109,7 @@ except FileNotFoundError:
             cp -r /home/\$NB_USER/usecases ./ &&
             cp -r /home/\$NB_USER/home_page.ipynb ./ &&
             jupyter lab --no-browser --NotebookApp.shutdown_button=True
-        #elif $mode.mode_select == 'github':
+        #elif $mode.mode_select == 'pull_repo':
             cp /home/\$NB_USER/home_page.ipynb ./ &&
             git clone $mode.repo_url &&
             jupyter lab --no-browser --NotebookApp.shutdown_button=True


### PR DESCRIPTION
Fix the GitHub repo feature for GPU Interactive tool. Because of this error, jobs did not start when pulling a repo feature was chosen.

ping @bgruening @sanjaysrikakulam  Thanks!

