### PR TITLE
Revert accidental overwrite in usegalaxy.eu of upstream changes to interactive tools

### DIFF
--- a/tools/interactive/interactivetool_cellxgene_1.1.1.xml
+++ b/tools/interactive/interactivetool_cellxgene_1.1.1.xml
@@ -15,20 +15,23 @@
 			   />
     </stdio>
     <command><![CDATA[
-        #import re
-        #set $fancy_name = '/tmp/galaxy_cellxgene_' + re.sub('[^\w\-_]', '_', $infile.element_identifier) + '.h5ad'
-	
-	#if $var_name
-	python '${anndata_unique_var_gene_symbols}' '${infile}' '${fancy_name}' '${var_name}'
-        #else  
-        cp '${infile}' '${fancy_name}'
-        #end if
-	&&
-	mkdir annotation_files
-	&&
-	cellxgene launch --host 0.0.0.0 --port 80 
+    #import re
+    #set $fancy_name = '/tmp/galaxy_cellxgene_' + re.sub('[^\w\-_]', '_', $infile.element_identifier) + '.h5ad'
+
+    #if ($var_name and $make_unique) or $layer:
+    python '${anndata_unique_var_gene_symbols}' '${infile}' '${fancy_name}' '${var_name}' '${make_unique}' '${layer}'
+    #else  
+    cp '${infile}' '${fancy_name}'
+    #end if
+    &&
+    mkdir annotation_files
+    &&
+    cellxgene launch --host 0.0.0.0 --port 80 
         --user-generated-data-dir annotation_files
-	'${fancy_name}'
+    #if $var_name and not $make_unique:
+        --var-names $var_name
+    #end if
+    '${fancy_name}'
     ]]>
     </command>
     <configfiles>
@@ -44,21 +47,31 @@ def rn(df, field, suffix = '-duplicate-'):
 adata = ad.read_h5ad(sys.argv[1])
 output = sys.argv[2]
 gene_symbol_field = sys.argv[3]
-if gene_symbol_field not in adata.var.keys():
-   sys.exit(f"Field {gene_symbol_field} set as var_name does not exist in the var object. AnnData object will be used as it was given")
+make_unique = (sys.argv[4].lower() == "true")
+layer = sys.argv[5]
 
-adata.var = rn(adata.var, gene_symbol_field, suffix = "_d")
+if gene_symbol_field and make_unique:
+    if gene_symbol_field not in adata.var.keys():
+        sys.exit(f"Field {gene_symbol_field} set as var_name does not exist in the var object. AnnData object will be used as it was given")
+    
+    adata.var = rn(adata.var, gene_symbol_field, suffix = "_d")
+    adata.var["extra_gene_id"] = adata.var.index
+    adata.var = adata.var.set_index(f"{gene_symbol_field}_u")
 
-adata.var["extra_gene_id"] = adata.var.index
-adata.var = adata.var.set_index(f"{gene_symbol_field}_u")
+if layer:
+    if layer not in adata.layers.keys():
+        sys.exit(f"Layer {layer} is not present in AnnData, only available layers are: {', '.join(adata.layers.keys())}")
+    else:
+        adata.X = adata.layers[layer]
 
-
-adata.write_h5ad(output, compression="gzip")
+adata.write_h5ad(output)
 ]]></configfile>
     </configfiles>
     <inputs>
 	<param name="infile" type="data" format="h5ad" label="Concatenate Dataset"/>
-        <param name="var_name" type="text" optional="true" label="Var field for gene symbols" help="Optionaly specify the var field from the AnnData file provided where gene symbols are available. Usually the AnnData file var slot will be indexed with gene symbols and this is not required. Using this option will delay the startup of the cellxgene tool, as the AnnData needs to be modified and re-written to disk."/>
+    <param name="var_name" type="text" optional="true" label="Var field for gene symbols" help="Optionaly specify the var field from the AnnData file provided where gene symbols are available. Usually the AnnData file var slot will be indexed with gene symbols and this is not required. Using this option will delay the startup of the cellxgene tool, as the AnnData needs to be modified and re-written to disk."/>
+    <param name="make_unique" type="boolean" checked="false" label="Make specified var field unique" help="It will copy the specified var field above and make its values unique. This means reading the AnnData object into Python and re-writing it again, increasing waiting time for the container to be up."/>
+    <param name="layer" type="text" optional="true" label="Specifies the AnnData layer to use as matrix" help="The layer name needs to be present in the AnnData file or this tool will fail"/>
     </inputs>
     <outputs>
 	<data name="out_file1" format="txt" />
@@ -80,9 +93,20 @@ Selecting the Var name
 ----------------------
 It can happen that the main index for the var element of AnnData is not the 
 gene symbol field, in which case search by genes will probably be by identifier.
-You can choose a different field (which contains the gene symbols) so that
+You can choose a different field and celxgene will use this. If in addition you choose "Make unique", 
 the AnnData is modified (in a new copy) so that that field is made unique and
-it is indexed by it. Then cellxgene will allow searches by genes in that field.
+it is indexed by it. Making it unique entails though loading the object into memory, 
+modifying and writing it back, which can delay the execution of cellxgene.
+
+Then cellxgene will allow searches by genes in that field.
+
+Selecting the layer
+-------------------
+
+It can happen that the AnnData object contains multiple layers, for example
+one with the raw counts and another with the normalised counts. You can select
+which layer to use as the matrix for cellxgene. By default cellxgene will use the X slot, but
+that slot might not contain the matrix that you want to visualise.
 
 Outputs
 -------

--- a/tools/interactive/interactivetool_guacamole_desktop.xml
+++ b/tools/interactive/interactivetool_guacamole_desktop.xml
@@ -3,7 +3,7 @@
         <container type="docker">quay.io/bgruening/guacamole-desktop</container>
     </requirements>
     <entry_points>
-        <entry_point name="Remote Desktop" requires_domain="True">
+        <entry_point name="Remote Desktop" requires_domain="False" requires_path_in_url="False">
             <port>8080</port>
             <url><![CDATA[?username=user&password=password]]></url>
         </entry_point>

--- a/tools/interactive/interactivetool_jupyter_notebook_1.0.0.xml
+++ b/tools/interactive/interactivetool_jupyter_notebook_1.0.0.xml
@@ -1,9 +1,9 @@
-<tool id="interactive_tool_jupyter_notebook" tool_type="interactive" name="Interactive JupyTool and notebook" version="1.0.0" profile="22.01">
+<tool id="interactive_tool_jupyter_notebook" tool_type="interactive" name="Interactive JupyterLab Notebook" version="1.0.0" profile="22.01">
     <requirements>
         <container type="docker">quay.io/bgruening/docker-jupyter-notebook:2021-03-05</container>
     </requirements>
     <entry_points>
-        <entry_point name="JupyTool interactive tool" requires_domain="True">
+        <entry_point name="JupyTool interactive tool" label="jupytool" requires_domain="False" requires_path_in_url="True">
             <port>8888</port>
             <url>ipython/lab</url>
         </entry_point>
@@ -14,6 +14,7 @@
         <environment_variable name="GALAXY_WEB_PORT">8080</environment_variable>
         <environment_variable name="GALAXY_URL">$__galaxy_url__</environment_variable>
         <environment_variable name="API_KEY" inject="api_key"/>
+        <environment_variable name="EP_PATH" inject="entry_point_path_for_label">jupytool</environment_variable>
     </environment_variables>
     <configfiles>
         <inputs name="inputs" filename="galaxy_inputs.json" data_style="staging_path_and_source_path"/>
@@ -80,6 +81,7 @@ except FileNotFoundError:
         export GALAXY_WORKING_DIR=`pwd` &&
         mkdir -p ./jupyter/outputs/collection &&
         mkdir -p ./jupyter/galaxy_inputs &&
+        export PROXY_PREFIX=\${EP_PATH%/ipython*} &&
 
         ## change into the directory where the notebooks are located
         cd ./jupyter/ &&

--- a/tools/interactive/interactivetool_mgnify_notebook.xml
+++ b/tools/interactive/interactivetool_mgnify_notebook.xml
@@ -1,6 +1,6 @@
-<tool id="interactive_tool_mgnify_notebook" tool_type="interactive" name="Interactive MGnify Notebook" version="0.0.1" profile="22.01">
+<tool id="interactive_tool_mgnify_notebook" tool_type="interactive" name="Interactive MGnify Notebook" version="1.2.2" profile="22.01">
     <requirements>
-        <container type="docker">quay.io/microbiome-informatics/emg-notebooks.dev:v1.0.1</container>
+        <container type="docker">quay.io/microbiome-informatics/emg-notebooks.dev:v1.2.2</container>
     </requirements>
     <entry_points>
         <entry_point name="MGnify Interactive Tool" requires_domain="True">

--- a/tools/interactive/interactivetool_openrefine.xml
+++ b/tools/interactive/interactivetool_openrefine.xml
@@ -4,7 +4,7 @@
         <container type="docker">ylebras/openrefine-docker</container>
     </requirements>
     <entry_points>
-        <entry_point name="Openrefine visualisation" requires_domain="True">
+        <entry_point name="Openrefine visualisation" requires_domain="False" requires_path_in_url="False">
             <port>3333</port>
         </entry_point>
     </entry_points>
@@ -17,7 +17,7 @@
     </environment_variables>
     <configfiles>
         <configfile name="start_openrefine"><![CDATA[
-exec /OpenRefine/refine -i 0.0.0.0 -m \${GALAXY_MEMORY_MB}M &
+exec /OpenRefine/refine -i 0.0.0.0 -m \$GALAXY_MEMORY_MB &
 
 ##Check if openrefine is up to work
 STATUS=\$(curl --include 'http://127.0.0.1:3333' 2>&1)
@@ -81,4 +81,3 @@ Example input file (TAB separated)::
 ]]>
     </help>
 </tool>
-

--- a/tools/interactive/interactivetool_pangeo_notebook.xml
+++ b/tools/interactive/interactivetool_pangeo_notebook.xml
@@ -1,6 +1,6 @@
 <tool id="interactive_tool_pangeo_notebook" tool_type="interactive" name="Interactive Pangeo Notebook" version="22.01" profile="22.01">
     <requirements>
-        <container type="docker">quay.io/nordicesmhub/docker-pangeo-notebook:2023.02.27</container>
+        <container type="docker">quay.io/nordicesmhub/docker-pangeo-notebook:1c0f66b</container>
     </requirements>
     <entry_points>
         <entry_point name="Pangeo Interactive Tool" requires_domain="True">

--- a/tools/interactive/interactivetool_rstudio.xml
+++ b/tools/interactive/interactivetool_rstudio.xml
@@ -3,14 +3,13 @@
         <container type="docker">quay.io/galaxy/docker-rstudio-notebook:23.1</container>
     </requirements>
     <entry_points>
-        <entry_point name="RStudio" requires_domain="True">
+        <entry_point name="RStudio" requires_domain="False" requires_path_in_header_named="X-RStudio-Root-Path">
             <port>8787</port>
             <url>/</url>
         </entry_point>
     </entry_points>
     <environment_variables>
         <environment_variable name="HISTORY_ID" strip="True">${__app__.security.encode_id($jupyter_notebook.history_id)}</environment_variable> <!-- FIXME: Warning: The use of __app__ is deprecated and will break backward compatibility in the near future -->
-        <environment_variable name="REMOTE_HOST">${__app__.config.galaxy_infrastructure_url}</environment_variable> <!-- FIXME: Warning: The use of __app__ is deprecated and will break backward compatibility in the near future -->
         <environment_variable name="GALAXY_WEB_PORT">8080</environment_variable>
         <environment_variable name="GALAXY_URL">$__galaxy_url__</environment_variable>
         <environment_variable name="DEBUG">true</environment_variable>


### PR DESCRIPTION
Several upstream changes to interactive tools have been accidentally overwritten in the commit: https://github.com/usegalaxy-eu/galaxy/commit/b33506b7780d438eccc5cce06c4d05e29873b470

I went through all the interactive tools that were also in the upstream branch and reverted the changes of those where the newest changes seemed to be upstream. As far as I can tell, accepting this PR in usegalaxy.eu and then creating a PR for all interactive tools back upstream would make upstream the gold source of interactive tools for usegalaxy.org and usegalaxy.eu.

Harmonisation with usegalaxy.com.au and other galaxy installations should also be done.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
