### PR TITLE
Add Cellpose interactive tool

### DIFF
--- a/tools/interactive/interactivetool_cellpose.xml
+++ b/tools/interactive/interactivetool_cellpose.xml
@@ -31,7 +31,7 @@
     
     <outputs>
         <collection name="cp_output" type="list" label="CellPose output">
-		<discover_datasets pattern="(?P&lt;name&gt;.*)(_masks\..*|_outlines\..*|\.npy|\.zip|_flows\..*)$" directory="./home/cp_working_dir" />
+		<discover_datasets pattern="__name_and_ext__" directory="./home/cp_working_dir" />
 	</collection>
     </outputs>
     

--- a/tools/interactive/interactivetool_cellpose.xml
+++ b/tools/interactive/interactivetool_cellpose.xml
@@ -1,10 +1,10 @@
-<tool id="interactive_tool_cellpose" tool_type="interactive" name="Run CellPose" version="@VERSION@+galaxy0" profile="23.1">
-	<description>interactive tool</description>
+<tool id="interactive_tool_cellpose" tool_type="interactive" name="CellPose Interactive" version="@VERSION@+galaxy0" profile="23.1">
+    <description>a generalist algorithm for cellular segmentation and restoration</description>
     <macros>
         <token name="@VERSION@">3.0.11</token>
     </macros>
     <requirements>
-	    <container type="docker">quay.io/sunyi000/cellpose-galaxy:v3.0.11</container>
+        <container type="docker">quay.io/sunyi000/cellpose-galaxy:v3.0.11</container>
     </requirements>
     <entry_points>
         <entry_point name="CellPose" requires_domain="True">
@@ -14,30 +14,27 @@
     <command detect_errors="exit_code">
     <![CDATA[
         export HOME=\$PWD &&
-		    
+            
         mkdir -p ./home ./home/cp_working_dir &&
         chown -R 1000:1000 ./home &&
         #for $i,$filename in enumerate($infiles):
-	    ln -s '$filename' './home/cp_working_dir/${filename.element_identifier}.${filename.ext}' &&
+        ln -s '$filename' './home/cp_working_dir/${filename.element_identifier}.${filename.ext}' &&
         #end for
               
-	/init 
+    /init 
     ]]>
     </command>
     <inputs>
-	<param name="infiles" type="data" multiple="true" format="jpg,png,tiff,bmp,gif,pcx,ppm,psd,pbm,pgm,eps" label="Images" />
-
+        <param name="infiles" type="data" multiple="true" format="jpg,png,tiff,bmp,gif,pcx,ppm,psd,pbm,pgm,eps" label="Images" />
     </inputs>
     
     <outputs>
         <collection name="cp_output" type="list" label="CellPose output">
-		<discover_datasets pattern="__name_and_ext__" directory="./home/cp_working_dir" />
-	</collection>
+            <discover_datasets pattern="__name_and_ext__" directory="./home/cp_working_dir" />
+        </collection>
     </outputs>
-    
     <tests>
     </tests>
-    
     <help><![CDATA[
 ]]>
     </help>

--- a/tools/interactive/interactivetool_cellpose.xml
+++ b/tools/interactive/interactivetool_cellpose.xml
@@ -1,0 +1,44 @@
+<tool id="interactive_tool_cellpose" tool_type="interactive" name="Run CellPose" version="@VERSION@+galaxy0" profile="23.1">
+	<description>interactive tool</description>
+    <macros>
+        <token name="@VERSION@">3.0.11</token>
+    </macros>
+    <requirements>
+	    <container type="docker">quay.io/sunyi000/cellpose-galaxy:v3.0.11</container>
+    </requirements>
+    <entry_points>
+        <entry_point name="CellPose" requires_domain="True">
+            <port>5800</port>
+        </entry_point>
+    </entry_points>
+    <command detect_errors="exit_code">
+    <![CDATA[
+        export HOME=\$PWD &&
+		    
+        mkdir -p ./home ./home/cp_working_dir &&
+        chown -R 1000:1000 ./home &&
+        #for $i,$filename in enumerate($infiles):
+	    ln -s '$filename' './home/cp_working_dir/${filename.element_identifier}.${filename.ext}' &&
+        #end for
+              
+	/init 
+    ]]>
+    </command>
+    <inputs>
+	<param name="infiles" type="data" multiple="true" format="jpg,png,tiff,bmp,gif,pcx,ppm,psd,pbm,pgm,eps" label="Images" />
+
+    </inputs>
+    
+    <outputs>
+        <collection name="cp_output" type="list" label="CellPose output">
+		<discover_datasets pattern="(?P&lt;name&gt;.*)(_masks\..*|_outlines\..*|\.npy|\.zip|_flows\..*)$" directory="./home/cp_working_dir" />
+	</collection>
+    </outputs>
+    
+    <tests>
+    </tests>
+    
+    <help><![CDATA[
+]]>
+    </help>
+</tool>


### PR DESCRIPTION
add CellPose 3.0.11 interactive tools

![Screenshot from 2024-09-19 16-54-15](https://github.com/user-attachments/assets/44cbe145-d550-4c29-8827-d6e36a08845e)

![Screenshot from 2024-09-19 16-53-41](https://github.com/user-attachments/assets/70e145f6-827b-4a1e-bd0f-0275a6b4ecc9)

![Screenshot from 2024-09-19 16-54-28](https://github.com/user-attachments/assets/9b5801e8-2ab6-459f-9097-e416fa0656af)

Tests:
1. upload image to Galaxy history
2. start CellPose interactive tool
3. Load image from /home/cp_working_dir

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
