### PR TITLE
Add rstudio askor

### DIFF
--- a/tools/interactive/interactivetool_rstudio_askor.xml
+++ b/tools/interactive/interactivetool_rstudio_askor.xml
@@ -1,0 +1,66 @@
+<tool id="interactive_tool_rstudio_askor" tool_type="interactive" name="RStudio AskoR" version="0.1">
+    <requirements>
+        <container type="docker">quay.io/genouest/docker-galaxy-rstudio-askor:0.1</container>
+    </requirements>
+    <entry_points>
+        <entry_point name="RStudio" requires_domain="True">
+            <port>80</port>
+            <url>rstudio/</url>
+        </entry_point>
+    </entry_points>
+    <environment_variables>
+        <environment_variable name="HISTORY_ID" strip="True">${__app__.security.encode_id($rstudio.history_id)}</environment_variable> <!-- FIXME: Warning: The use of __app__ is deprecated and will break backward compatibility in the near future -->
+        <environment_variable name="REMOTE_HOST">${__app__.config.galaxy_infrastructure_url}</environment_variable> <!-- FIXME: Warning: The use of __app__ is deprecated and will break backward compatibility in the near future -->
+        <environment_variable name="GALAXY_WEB_PORT">8080</environment_variable>
+        <environment_variable name="GALAXY_URL">$__galaxy_url__</environment_variable>
+        <environment_variable name="DEBUG">true</environment_variable>
+        <environment_variable name="DISABLE_AUTH">true</environment_variable>
+        <environment_variable name="API_KEY" inject="api_key" />
+    </environment_variables>
+    <command detect_errors="aggressive"><![CDATA[
+        #import re
+        export GALAXY_WORKING_DIR=`pwd` &&
+        mkdir -p ./rstudio/outputs/ &&
+        mkdir -p ./rstudio/data &&
+
+        ## change into the directory where the notebooks are located
+        cd ./rstudio/ &&
+
+        sed -i 's|/monitor.*||g' /etc/services.d/nginx/run &&
+
+        /etc/init.d/syslog-ng start &&
+        /init &
+        ##rstudio-server start &&
+        sleep 5 &&
+
+        chmod 777 /tmp -R &&
+        tail -f /var/log/rstudio-server/rserver.log
+
+    ]]>
+    </command>
+    <inputs>
+    </inputs>
+    <outputs>
+        <data name="rstudio" format="txt" label=""></data>
+    </outputs>
+    <tests>
+    </tests>
+    <help>
+    This tool runs an RStudio instance with the AskoR tool preinstalled. AskoR is an R pipeline for gene expression
+    analysis from RNAseq data. It allows, through the articulation of well-known R packages (EdgeR, UpSetR, topGO, Coseq),
+    to perform a complete and automatic transcriptomic analysis: data filtering, normalisation of filtered data, descriptive
+    analysis of data quality, differential gene expression analysis, enrichment in terms of "Gene Ontology",
+    clustering genes by co-expression profile, and enhanced with multiple graphic representations.
+
+    For more information on AskoR, have a look at https://github.com/askomics/askoR.
+
+    It also comes with ggplot2, RODBC, maps, shinyapps, knitr,
+    LaTeX, bioconductor, cummeRbund, and many more pre-installed packages.
+
+    Galaxy offers you to use RStudio directly in Galaxy accessing and interacting with Galaxy datasets as you like.
+
+    The convenience functions gx_put() and gx_get() are available to you to interact with your current Galaxy history. You can save your workspace with gx_save().
+
+    For example, gx_get(42) will fetch dataset 42 from your history and return the file location
+    </help>
+</tool>


### PR DESCRIPTION
Just adding a rstudio gxit from usegalaxy.fr, that we were asked to disable as a precaution, until we get a green light from security folks (consequence of bitcoin mining in jupyter notebooks).

It's based on this Docker image: https://github.com/genouest/docker-galaxy-rstudio-askor = just the rstudio one (not the latest) with a few packages pre installed.

This is needed for some trainings in the coming weeks

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
