### PR TITLE
Don't use celery for notifications (usegalaxy-eu/issues/issues/624)

### DIFF
--- a/lib/galaxy/webapps/galaxy/services/notifications.py
+++ b/lib/galaxy/webapps/galaxy/services/notifications.py
@@ -64,7 +64,7 @@ class NotificationService(ServiceBase):
             recipients=payload.recipients,
             galaxy_url=galaxy_url,
         )
-        return self.send_notification_internal(request)
+        return self.send_notification_internal(request, force_sync=True)
 
     def send_notification_internal(
         self, request: NotificationCreateRequest, force_sync: bool = False


### PR DESCRIPTION
Co-authored-by: @davelopez (I did not manage to do it properly in git)

Temporary fix for [#624](https://github.com/usegalaxy-eu/issues/issues/624)

This means that galaxy guinicorn handlers will do the notification delivery for now and we should be careful/avoid sending *notifications* to larger recipient groups.
(*broadcasts* are not affected)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]
- [x] tested in production
## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
