### PR TITLE
Update interactivetool_openrefine.xml to 2024 tag openrefine image

### DIFF
--- a/tools/interactive/interactivetool_openrefine.xml
+++ b/tools/interactive/interactivetool_openrefine.xml
@@ -1,7 +1,7 @@
 <tool id="interactive_tool_openrefine" tool_type="interactive" name="OpenRefine" version="0.2">
     <description>Working with messy data</description>
     <requirements>
-        <container type="docker">ylebras/openrefine-docker</container>
+        <container type="docker">ylebras/openrefine-docker:2024</container>
     </requirements>
     <entry_points>
         <entry_point name="Openrefine visualisation" requires_domain="False" requires_path_in_url="False">


### PR DESCRIPTION
Tag version changed for openrefine image so the image can use a recent version of openrefine and will reactivate the functionalities to import data from Galaxy and export data to Galaxy history!

## How to test the changes?
Using it

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
