### PR TITLE
Update JupyterGIS notebook container image

### DIFF
--- a/tools/interactive/interactivetool_jupytergis_notebook.xml
+++ b/tools/interactive/interactivetool_jupytergis_notebook.xml
@@ -1,6 +1,6 @@
 <tool id="interactive_tool_jupytergis_notebook" tool_type="interactive" name="Interactive JupyterGIS Notebook" version="0.1" profile="23.01">
     <requirements>
-        <container type="docker">quay.io/annefou/docker-jupytergis-notebook:0.1.7.5</container>
+        <container type="docker">quay.io/annefou/docker-jupytergis-notebook:0.4.2</container>
     </requirements>
     <entry_points>
        <!-- needs to be requires_domain="True" because the GIX extension creates URL like:

--- a/tools/interactive/interactivetool_jupytergis_notebook.xml
+++ b/tools/interactive/interactivetool_jupytergis_notebook.xml
@@ -14,7 +14,6 @@
         <environment_variable name="REMOTE_HOST">$__galaxy_url__</environment_variable>
         <environment_variable name="GALAXY_WEB_PORT">8080</environment_variable>
         <environment_variable name="GALAXY_URL">$__galaxy_url__</environment_variable>
-        <environment_variable name="API_KEY" inject="api_key"/>
         <environment_variable name="EP_PATH" inject="entry_point_path_for_label">jupytergis</environment_variable>
     </environment_variables>
     <configfiles>


### PR DESCRIPTION
In this PR, the version of JupyterGIS notebook tool is upgraded due to the old version being out-of-date, and the API_KEY environment variable is removed from the XML file since it is not needed anymore. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [X] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
