### PR TITLE
interactivetool_pcstudio.xml for SMB conf

### DIFF
--- a/tools/interactive/interactivetool_pcstudio.xml
+++ b/tools/interactive/interactivetool_pcstudio.xml
@@ -1,16 +1,23 @@
 <tool id="interactive_tool_pcstudio" tool_type="interactive" name="PhysiCell Studio" version="@VERSION@" profile="22.05">
-    <description>graphical tool to create, execute, and visualize a multicellular model using PhysiCell</description>
+    <description>Interactive tool to create, simulate, and visualize a multicellular model using PhysiCell</description>
     <macros>
-        <token name="@VERSION@">1.3.1-1</token>
+        <token name="@VERSION@">0.2</token>
     </macros>
     <requirements>
-        <container type="docker">quay.io/galaxy/docker-pcstudio:@VERSION@</container>
+        <container type="docker">quay.io/physicell/pcstudio:@VERSION@</container>
     </requirements>
     <entry_points>
         <entry_point name="PhysiCell Studio" requires_domain="True">
             <port>5800</port>
         </entry_point>
     </entry_points>
+    <environment_variables>
+        <environment_variable name="HISTORY_ID">$__history_id__</environment_variable>
+        <environment_variable name="REMOTE_HOST">$__galaxy_url__</environment_variable>
+        <environment_variable name="GALAXY_WEB_PORT">8080</environment_variable>
+        <environment_variable name="GALAXY_URL">$__galaxy_url__</environment_variable>
+        <environment_variable name="API_KEY" inject="api_key" />
+    </environment_variables>
     <command detect_errors="exit_code">
     <![CDATA[
         mkdir -p ./output &&
@@ -24,7 +31,7 @@
     ]]>
     </command>
     <inputs>
-        <!--param name="infile" type="data" format="tiff" label="Input file in TIFF format"/-->
+        <param name="config_file"  type="data" format="xml" label="xml config file" optional="true"/>
     </inputs>
     <outputs>
         <data name="final_svg" format="svg" label="${tool.name} on ${on_string}: final.svg"/>
@@ -37,6 +44,8 @@
         </collection-->
     </outputs>
     <tests>
+        <test>
+        </test>
     </tests>
     <help><![CDATA[
 
@@ -46,6 +55,7 @@ A graphical tool to create, execute, and visualize a multicellular model using P
     </help>
     <citations>
         <citation type="doi">10.1371/journal.pcbi.1005991</citation>
-        <citation type="doi">10.46471/gigabyte.128</citation>      
+        <citation type="doi">10.46471/gigabyte.128</citation>
+        <citation type="doi">10.1101/2023.09.17.557982</citation>
     </citations>
 </tool>


### PR DESCRIPTION
This is an updated version of the PhysiCell Studio interactive tool (in preparation for the Society for Math Bio conference). It uses a Docker container now located at `quay.io/physicell` . Its .xml config now includes `<environment_variables>` that are necessary for the new functionality using the `put()` Python function from `galaxy_ie_helpers`. The goal there is to allow saving results before the tool exits. I encountered several issues which prevented me from testing this tool on a local Galaxy instance.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [X] Instructions for manual testing are as follows:
  * Minimal test: run the tool and select `File -> put on History -> current config .xml`. Does it save `PhysiCell_settings.xml` onto the Galaxy History?
  * On the `Config Basics` tab, set `Max Time`=360 mins. On the `Run` tab, press Run Simulation and let it complete (takes just a few secs). Try to use `File -> put on History -> all_csv.zip` (and `all_output.zip`) to see if they appear in the Galaxy History.

## License
- [ ] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
