### PR TITLE
use updated docker; remove IT's input arg

### DIFF
--- a/tools/interactive/interactivetool_pcstudio.xml
+++ b/tools/interactive/interactivetool_pcstudio.xml
@@ -1,16 +1,23 @@
 <tool id="interactive_tool_pcstudio" tool_type="interactive" name="PhysiCell Studio" version="@VERSION@" profile="22.05">
-    <description>graphical tool to create, execute, and visualize a multicellular model using PhysiCell</description>
+    <description>Interactive tool to create, simulate, and visualize a multicellular model using PhysiCell</description>
     <macros>
-        <token name="@VERSION@">1.3.1-1</token>
+        <token name="@VERSION@">0.2</token>
     </macros>
     <requirements>
-        <container type="docker">quay.io/galaxy/docker-pcstudio:@VERSION@</container>
+        <container type="docker">quay.io/physicell/pcstudio:@VERSION@</container>
     </requirements>
     <entry_points>
         <entry_point name="PhysiCell Studio" requires_domain="True">
             <port>5800</port>
         </entry_point>
     </entry_points>
+    <environment_variables>
+        <environment_variable name="HISTORY_ID">$__history_id__</environment_variable>
+        <environment_variable name="REMOTE_HOST">$__galaxy_url__</environment_variable>
+        <environment_variable name="GALAXY_WEB_PORT">8080</environment_variable>
+        <environment_variable name="GALAXY_URL">$__galaxy_url__</environment_variable>
+        <environment_variable name="API_KEY" inject="api_key" />
+    </environment_variables>
     <command detect_errors="exit_code">
     <![CDATA[
         mkdir -p ./output &&
@@ -24,7 +31,7 @@
     ]]>
     </command>
     <inputs>
-        <!--param name="infile" type="data" format="tiff" label="Input file in TIFF format"/-->
+        <param name="config_file"  type="data" format="xml" label="xml config file" optional="true"/>
     </inputs>
     <outputs>
         <data name="final_svg" format="svg" label="${tool.name} on ${on_string}: final.svg"/>
@@ -37,6 +44,8 @@
         </collection-->
     </outputs>
     <tests>
+        <test>
+        </test>
     </tests>
     <help><![CDATA[
 
@@ -46,6 +55,7 @@ A graphical tool to create, execute, and visualize a multicellular model using P
     </help>
     <citations>
         <citation type="doi">10.1371/journal.pcbi.1005991</citation>
-        <citation type="doi">10.46471/gigabyte.128</citation>      
+        <citation type="doi">10.46471/gigabyte.128</citation>
+        <citation type="doi">10.1101/2023.09.17.557982</citation>
     </citations>
 </tool>

--- a/tools/interactive/interactivetool_pcstudio.xml
+++ b/tools/interactive/interactivetool_pcstudio.xml
@@ -1,7 +1,7 @@
 <tool id="interactive_tool_pcstudio" tool_type="interactive" name="PhysiCell Studio" version="@VERSION@" profile="22.05">
     <description>Interactive tool to create, simulate, and visualize a multicellular model using PhysiCell</description>
     <macros>
-        <token name="@VERSION@">0.2</token>
+        <token name="@VERSION@">0.3</token>
     </macros>
     <requirements>
         <container type="docker">quay.io/physicell/pcstudio:@VERSION@</container>
@@ -31,7 +31,9 @@
     ]]>
     </command>
     <inputs>
+    <!--
         <param name="config_file"  type="data" format="xml" label="xml config file" optional="true"/>
+    -->
     </inputs>
     <outputs>
         <data name="final_svg" format="svg" label="${tool.name} on ${on_string}: final.svg"/>


### PR DESCRIPTION
Fixed IT (Docker) code to "put" zipped output files to the History. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Use `File -> put on History -> all_*.zip` menu items, after running a very brief default simulation
  2. Verify the IT's optional input argument (.xml config file) no longer appears on the Galaxy startup panel

## License
- [] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
