### PR TITLE
Workaround bug accessing S3 object stores

### DIFF
--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -13,7 +13,7 @@ axe-selenium-python==2.1.6
 babel==2.17.0
 backports-tarfile==1.2.0 ; python_full_version < '3.12' and platform_machine != 'ppc64le' and platform_machine != 's390x'
 black==25.1.0
-boto3==1.37.1
+boto3==1.35
 botocore==1.37.1
 build==1.2.2.post1
 cachecontrol==0.14.2

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -2,7 +2,7 @@
 #    uv export --frozen --no-annotate --no-hashes --no-dev
 a2wsgi==1.10.8
 adal==1.2.7
-aiobotocore==2.21.1
+aiobotocore==2.15.2
 aiofiles==24.1.0
 aiohappyeyeballs==2.6.1
 aiohttp==3.11.18
@@ -30,7 +30,7 @@ bioblend==1.5.0
 bleach==6.2.0
 boltons==25.0.0
 boto==2.49.0
-botocore==1.37.1
+botocore==1.35.36
 bx-python==0.13.0
 cachecontrol==0.14.2
 celery==5.5.2

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -29,7 +29,7 @@ billiard==4.2.1
 bioblend==1.5.0
 bleach==6.2.0
 boltons==25.0.0
-boto==2.49.0
+boto==2.49.0  # this comment generates a merge conflict if this dependency is updated upstream
 botocore==1.35.36
 bx-python==0.13.0
 cachecontrol==0.14.2


### PR DESCRIPTION
Pin S3 library versions (`botocore==1.35.36`, `boto==2.49.0`, `aiobotocore==2.15.2`, `boto3==1.35`) to work around bug (https://github.com/galaxyproject/galaxy/issues/20495) accessing S3 object stores.

`boto` is already pinned to `boto==2.49.0`.
