### PR TITLE
Update JupyterGIS version to 0.6.2

### DIFF
--- a/tools/interactive/interactivetool_jupytergis_notebook.xml
+++ b/tools/interactive/interactivetool_jupytergis_notebook.xml
@@ -1,7 +1,7 @@
 <tool id="interactive_tool_jupytergis_notebook" tool_type="interactive" name="Interactive JupyterGIS Notebook" version="0.1" profile="23.01">
     <icon src="jupytergis.png"/>
     <requirements>
-        <container type="docker">quay.io/annefou/docker-jupytergis-notebook:0.4.2</container>
+        <container type="docker">quay.io/annefou/docker-jupytergis-notebook:0.6.2</container>
     </requirements>
     <entry_points>
        <!-- needs to be requires_domain="True" because the GIX extension creates URL like:


### PR DESCRIPTION
Updated the JupyterGIS interactive tool version from 0.4.2 to 0.6.2

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [X] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
