### PR TITLE
Change paraview container from `sunyi000` to `bmcv`

### DIFF
--- a/tools/interactive/interactivetool_paraview.xml
+++ b/tools/interactive/interactivetool_paraview.xml
@@ -1,7 +1,7 @@
 <tool id="interactive_tool_paraview" tool_type="interactive" name="Paraview" version="v5.12+galaxy02" profile="24.2">
     <icon src="paraview.png"/>
     <requirements>
-        <container type="docker">quay.io/bmcv/docker-paraview:v5.12</container>
+        <container type="docker">quay.io/bmcv/docker-paraview:v5.11</container>
     </requirements>
     <entry_points>
         <entry_point name="Paraview">

--- a/tools/interactive/interactivetool_paraview.xml
+++ b/tools/interactive/interactivetool_paraview.xml
@@ -1,4 +1,4 @@
-<tool id="interactive_tool_paraview" tool_type="interactive" name="Paraview" version="v5.12+galaxy02" profile="24.2">
+<tool id="interactive_tool_paraview" tool_type="interactive" name="Paraview" version="v5.11+galaxy01" profile="24.2">
     <icon src="paraview.png"/>
     <requirements>
         <container type="docker">quay.io/bmcv/docker-paraview:v5.11</container>

--- a/tools/interactive/interactivetool_paraview.xml
+++ b/tools/interactive/interactivetool_paraview.xml
@@ -1,7 +1,7 @@
 <tool id="interactive_tool_paraview" tool_type="interactive" name="Paraview" version="v5.12+galaxy02" profile="24.2">
     <icon src="paraview.png"/>
     <requirements>
-        <container type="docker">quay.io/sunyi000/docker-paraview:v5.12</container>
+        <container type="docker">quay.io/bmcv/docker-paraview:v5.12</container>
     </requirements>
     <entry_points>
         <entry_point name="Paraview">


### PR DESCRIPTION
This is a follow-up of #311 

After discussing the matter with @sunyi000 we decided to relocate the container image from
```
quay.io/sunyi000/docker-paraview:v5.12
```
to
```
quay.io/bmcv/docker-paraview:v5.12
```