### PR TITLE
Ilastik update

### DIFF
--- a/tools/interactive/interactivetool_ilastik.xml
+++ b/tools/interactive/interactivetool_ilastik.xml
@@ -36,7 +36,11 @@
 
         ## Link input images to current working directory
         #for input in $infiles:
-            ln -s '$input' ./'$input.element_identifier' &&
+            #if $input.element_identifier.endswith($input.ext):
+                ln -s '$input' ./'$input.element_identifier' &&
+            #else:
+                ln -s '$input' ./${input.element_identifier}.${input.ext} &&
+            #end if
         #end for
         ## Write the bash script to run:
         #if str($input_type.existing) == "new":
@@ -52,8 +56,6 @@
         if [ -n "\$(ls -A ./zarr_output)" ]; then
 	    cp -r ./zarr_output/* $zarr_output.extra_files_path; 
         fi
-	
-
     ]]>
     </command>
     <inputs>
@@ -87,25 +89,20 @@
             </when>
         </conditional>
         <param name="infiles" type="data" format="tiff,h5" multiple="true" label="Input files in TIFF or h5 format"/>
-    </inputs>
-    
+    </inputs>    
     <outputs>
         <data name="ilastik_project" format="h5" label="Ilastik project file" from_work_dir="output/MyProject.ilp"/>
-	<data name="zarr_output" format="zarr" label="Output OME-Zarr" />
+	<data name="zarr_output" format="ome_zarr" label="Output OME-Zarr" />
     </outputs>
-    
     <tests>
     </tests>
-    
     <help><![CDATA[
         Leverage machine learning algorithms to easily segment, classify, track and count your cells or other experimental data. Most operations are interactive, even on large datasets: you just draw the labels and immediately see the result. No machine learning expertise required.
 
         This tool has been designed uniquely to make/modify a project.
-        
         - It requires that input images have unique identifiers.
         - When you have trained your project, save it and quit the application. The project called 'MyProject.ilp' will be imported into your history.
         - If you want to modify a project, make sure you use at least the same images (with the same identifiers) as the first time (but you can add more).
-
         Please, check the documentation at https://www.ilastik.org/documentation/.
 ]]>
     </help>
@@ -113,4 +110,3 @@
         <citation type="doi">10.1038/s41592-019-0582-9</citation>
     </citations>
 </tool>
-

--- a/tools/interactive/interactivetool_ilastik.xml
+++ b/tools/interactive/interactivetool_ilastik.xml
@@ -1,8 +1,7 @@
-<tool id="interactive_tool_ilastik" tool_type="interactive" name="Ilastik" version="@VERSION@" profile="23.0">
+<tool id="interactive_tool_ilastik" tool_type="interactive" name="Ilastik" version="@VERSION@" profile="24.2">
     <description>interactive learning and segmentation toolkit</description>
-    <icon src="ilastik.png"/>
     <macros>
-        <token name="@VERSION@">1.4.0</token>
+        <token name="@VERSION@">1.4.1.post1</token>
     </macros>
     <requirements>
         <container type="docker">quay.io/galaxy/ilastik:@VERSION@</container>
@@ -27,8 +26,8 @@
         #end if
         export HOME=\$PWD &&
         ## Create a directory where the app user has access
-        mkdir -p ./output &&
-        chown 1000:1000 ./output/ &&
+        mkdir -p ./output ./zarr_output &&
+	chown 1000:1000 ./output/ ./zarr_output &&
         ## Make a copy of the existing project if exists
         #if str($input_type.existing) == "existing":
             cp '$input_type.project' ./output/MyProject.ilp &&
@@ -36,7 +35,7 @@
 
         ## Link input images to current working directory
         #for input in $infiles:
-            ln -s '$input' ./'$input.element_identifier'.tif &&
+            ln -s '$input' ./'$input.element_identifier' &&
         #end for
         ## Write the bash script to run:
         #if str($input_type.existing) == "new":
@@ -47,7 +46,13 @@
         ## Copy it to /bin/ so it will be used by the container:
         chmod +x ./ilastik_with_args &&
         cp ./ilastik_with_args '/bin/' &&
-        /init
+        /init  &&
+        
+        if [ -n "\$(ls -A ./zarr_output)" ]; then
+	    cp -r ./zarr_output/* $zarr_output.extra_files_path; 
+        fi
+	
+
     ]]>
     </command>
     <inputs>
@@ -80,21 +85,22 @@
                 <param argument="--project" type="data" format="h5" label="Existing ilastik project" />
             </when>
         </conditional>
-        <param name="infiles" type="data" format="tiff" multiple="true" label="Input files in TIFF format"/>
+        <param name="infiles" type="data" format="tiff,h5" multiple="true" label="Input files in TIFF or h5 format"/>
     </inputs>
-
+    
     <outputs>
         <data name="ilastik_project" format="h5" label="Ilastik project file" from_work_dir="output/MyProject.ilp"/>
+	<data name="zarr_output" format="zarr" label="Output OME-Zarr" />
     </outputs>
-
+    
     <tests>
     </tests>
-
+    
     <help><![CDATA[
         Leverage machine learning algorithms to easily segment, classify, track and count your cells or other experimental data. Most operations are interactive, even on large datasets: you just draw the labels and immediately see the result. No machine learning expertise required.
 
         This tool has been designed uniquely to make/modify a project.
-
+        
         - It requires that input images have unique identifiers.
         - When you have trained your project, save it and quit the application. The project called 'MyProject.ilp' will be imported into your history.
         - If you want to modify a project, make sure you use at least the same images (with the same identifiers) as the first time (but you can add more).
@@ -106,3 +112,4 @@
         <citation type="doi">10.1038/s41592-019-0582-9</citation>
     </citations>
 </tool>
+

--- a/tools/interactive/interactivetool_ilastik.xml
+++ b/tools/interactive/interactivetool_ilastik.xml
@@ -28,7 +28,7 @@
         export HOME=\$PWD &&
         ## Create a directory where the app user has access
         mkdir -p ./output ./zarr_output &&
-	chown 1000:1000 ./output/ ./zarr_output &&
+        chown 1000:1000 ./output/ ./zarr_output &&
         ## Make a copy of the existing project if exists
         #if str($input_type.existing) == "existing":
             cp '$input_type.project' ./output/MyProject.ilp &&

--- a/tools/interactive/interactivetool_ilastik.xml
+++ b/tools/interactive/interactivetool_ilastik.xml
@@ -1,5 +1,6 @@
 <tool id="interactive_tool_ilastik" tool_type="interactive" name="Ilastik" version="@VERSION@" profile="24.2">
     <description>interactive learning and segmentation toolkit</description>
+    <icon src="ilastik.png"/>
     <macros>
         <token name="@VERSION@">1.4.1.post1</token>
     </macros>


### PR DESCRIPTION
sorry i closed the other one, and open this PR with clean history
@bgruening @beatrizserrano

- update ilastik to newer version 1.4.1.post1
- add support to export image to single-scale ome-zarr
- to see output ome-zarr in Galaxy history, user will have to put it under the `zarr_output` folder

<img width="1786" height="811" alt="Screenshot From 2025-11-18 15-55-14" src="https://github.com/user-attachments/assets/2ab8e3b1-1257-4d9e-984e-46a6dd2c5309" />

