### PR TITLE
remove 2-d assertion in iou testing code to allow 3D or n-D images

### DIFF
--- a/lib/galaxy/tool_util/verify/__init__.py
+++ b/lib/galaxy/tool_util/verify/__init__.py
@@ -527,7 +527,7 @@ def intersection_over_union(
     This is particularly useful when specific image regions must always be labeled with a designated label value (e.g., the image background is often labeled with 0 or -1).
     """
     assert mask1.dtype == mask2.dtype
-    assert mask1.ndim == mask2.ndim == 2
+    assert mask1.ndim == mask2.ndim
     assert mask1.shape == mask2.shape
     for label in pin_labels or []:
         count = sum(label in mask for mask in (mask1, mask2))

--- a/tools/interactive/interactivetool_ilastik.xml
+++ b/tools/interactive/interactivetool_ilastik.xml
@@ -89,7 +89,7 @@
             </when>
         </conditional>
         <param name="infiles" type="data" format="tiff,h5" multiple="true" label="Input files in TIFF or h5 format"/>
-    </inputs>    
+    </inputs>
     <outputs>
         <data name="ilastik_project" format="h5" label="Ilastik project file" from_work_dir="output/MyProject.ilp"/>
 	<data name="zarr_output" format="ome_zarr" label="Output OME-Zarr" />
@@ -100,9 +100,11 @@
         Leverage machine learning algorithms to easily segment, classify, track and count your cells or other experimental data. Most operations are interactive, even on large datasets: you just draw the labels and immediately see the result. No machine learning expertise required.
 
         This tool has been designed uniquely to make/modify a project.
+        
         - It requires that input images have unique identifiers.
         - When you have trained your project, save it and quit the application. The project called 'MyProject.ilp' will be imported into your history.
         - If you want to modify a project, make sure you use at least the same images (with the same identifiers) as the first time (but you can add more).
+
         Please, check the documentation at https://www.ilastik.org/documentation/.
 ]]>
     </help>


### PR DESCRIPTION
this change is to enable iou testing for N-D images. this is related to https://github.com/FAIR-imaging/galaxy-image-community/issues/51
@kostrykin @beatrizserrano @bgruening 

I also looked at the internal function `_singleobject_intersection_over_union` and ` _multiobject_intersection_over_union`. they seem to already work with N-dimension. 

so I think to enable iou testing for 3D or n-D images, this (removing assertion) is the only change needed.

