### PR TITLE
Update interactivetool_qgis3_34.xml  to make outputs in Galaxy

### DIFF
--- a/tools/interactive/interactivetool_qgis3_34.xml
+++ b/tools/interactive/interactivetool_qgis3_34.xml
@@ -15,8 +15,8 @@
     <command detect_errors="exit_code">
     <![CDATA[
         export HOME=\$PWD &&
-        mkdir -p ./galaxy/data &&
-        mkdir -p ./galaxy/output &&
+        mkdir -p ./data &&
+        mkdir -p ./output &&
         chown 1000:1000 ./galaxy/output/ && ## change permission for the app user
         #if $infiles:
             #for $infile in $infiles:

--- a/tools/interactive/interactivetool_qgis3_34.xml
+++ b/tools/interactive/interactivetool_qgis3_34.xml
@@ -17,10 +17,10 @@
         export HOME=\$PWD &&
         mkdir -p ./data &&
         mkdir -p ./output &&
-        chown 1000:1000 ./galaxy/output/ && ## change permission for the app user
+        chown 1000:1000 ./output/ && ## change permission for the app user
         #if $infiles:
             #for $infile in $infiles:
-                yes | cp '$infile' './galaxy/data/$infile.display_name' &&
+                yes | cp '$infile' './data/$infile.display_name' &&
             #end for
         #end if
         /init


### PR DESCRIPTION
Tested and ok!

Seems that this version of QGIS is not exporting output datasets (from the GQGIS output folder) in Galaxy history when stopping the QGIS instance. Searching why, it appears to me that here, compare to the previous version of QGIS Galaxy tool, we are using /galaxy/output as folder instead of "just" /output. Do you think this can be the reason why, or the new QGIS image is not using the same PATH ?

