### PR TITLE
Add AI plugin API to enable JupyterLite AI on usegalaxy.eu

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -4032,6 +4032,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/plugins/{plugin_name}/chat/completions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Plugins Chat Adapter
+         * @description **Warning**: This API is unstable and may change without notice.
+         */
+        post: operations["plugins_chat_adapter_api_plugins__plugin_name__chat_completions_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/proxy": {
         parameters: {
             query?: never;
@@ -7326,6 +7346,40 @@ export interface components {
              */
             type: "change_dbkey";
         };
+        /** ChatCompletionRequest */
+        ChatCompletionRequest: {
+            /** Max Tokens */
+            max_tokens?: number | null;
+            /** Messages */
+            messages: components["schemas"]["ChatMessage"][];
+            /**
+             * Stream
+             * @default false
+             */
+            stream: boolean | null;
+            /** Tools */
+            tools?: components["schemas"]["ChatTool"][] | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /** ChatMessage */
+        ChatMessage: {
+            /** Content */
+            content?: string | null;
+            /**
+             * Role
+             * @enum {string}
+             */
+            role: "assistant" | "system" | "tool" | "user";
+            /** Tool Calls */
+            tool_calls?:
+                | {
+                      [key: string]: unknown;
+                  }[]
+                | null;
+        } & {
+            [key: string]: unknown;
+        };
         /** ChatPayload */
         ChatPayload: {
             /**
@@ -7357,6 +7411,24 @@ export interface components {
              * @description The response to the chat query.
              */
             response: string;
+        };
+        /** ChatTool */
+        ChatTool: {
+            function: components["schemas"]["ChatToolFunction"];
+            /**
+             * Type
+             * @constant
+             */
+            type: "function";
+        } & {
+            [key: string]: unknown;
+        };
+        /** ChatToolFunction */
+        ChatToolFunction: {
+            /** Name */
+            name: string;
+        } & {
+            [key: string]: unknown;
         };
         /** CheckForUpdatesResponse */
         CheckForUpdatesResponse: {
@@ -36987,6 +37059,54 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SharingStatus"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    plugins_chat_adapter_api_plugins__plugin_name__chat_completions_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description Visualization plugin name used to resolve the AI prompt. */
+                plugin_name: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ChatCompletionRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
             /** @description Request Error */

--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -522,6 +522,15 @@ class FrameworkRouter(APIRouter):
             openapi_extra["security"] = []
         if openapi_extra:
             kwd["openapi_extra"] = openapi_extra
+
+        unstable = kwd.pop("unstable", False)
+        if unstable:
+            warning = "**Warning**: This API is unstable and may change without notice.\n\n"
+            if "description" in kwd:
+                kwd["description"] = warning + kwd["description"]
+            else:
+                kwd["description"] = warning
+
         return kwd
 
     @property

--- a/lib/galaxy/webapps/galaxy/api/plugins.py
+++ b/lib/galaxy/webapps/galaxy/api/plugins.py
@@ -2,21 +2,261 @@
 Plugins resource control over the API.
 """
 
+import json
 import logging
+from typing import (
+    Any,
+    cast,
+    Literal,
+    Optional,
+)
 
-from galaxy import exceptions
+from fastapi import (
+    Body,
+    Path,
+    Request,
+)
+from fastapi.responses import (
+    JSONResponse,
+    StreamingResponse,
+)
+from openai import (
+    APIError,
+    AsyncOpenAI,
+)
+from openai._streaming import AsyncStream
+from openai.types.chat import (
+    ChatCompletion,
+    ChatCompletionChunk,
+    ChatCompletionMessageParam,
+    ChatCompletionToolParam,
+)
+from pydantic import BaseModel
+
+from galaxy.config import GalaxyAppConfiguration
+from galaxy.exceptions import (
+    MessageException,
+    ObjectNotFound,
+)
 from galaxy.managers import (
     hdas,
     histories,
 )
+from galaxy.model import User
+from galaxy.structured_app import StructuredApp
 from galaxy.util import asbool
 from galaxy.web import expose_api_anonymous_and_sessionless
-from . import (
+from galaxy.webapps.galaxy.api import (
     BaseGalaxyAPIController,
     depends,
+    DependsOnApp,
+    DependsOnUser,
+    Router,
 )
+from galaxy.webapps.galaxy.fast_app import limiter
 
 log = logging.getLogger(__name__)
+
+router = Router(tags=["jobs"])
+
+GALAXY_PROMPT = """
+You are a Galaxy agent.
+You assist users with scientific data analysis and research workflows.
+Respond only to scientific, computational, or data analysis related questions.
+"""
+
+# Set constants
+MAX_MESSAGES = 1024
+MAX_TOOLS = 128
+MAX_TOOL_BYTES = 16384
+TEMPERATURE = 0.3
+TIMEOUT = 120.0
+TOKENS_DEFAULT = 1024
+TOKENS_MAX = 8192
+TOP_P = 0.9
+
+
+class ChatMessage(BaseModel):
+    role: Literal["assistant", "system", "tool", "user"]
+    content: Optional[str] = None
+    tool_calls: Optional[list[dict[str, Any]]] = None
+    model_config = dict(extra="allow")
+
+
+class ChatToolFunction(BaseModel):
+    name: str
+    model_config = dict(extra="allow")
+
+
+class ChatTool(BaseModel):
+    type: Literal["function"]
+    function: ChatToolFunction
+    model_config = dict(extra="allow")
+
+
+class ChatCompletionRequest(BaseModel):
+    messages: list[ChatMessage]
+    tools: Optional[list[ChatTool]] = None
+    stream: Optional[bool] = False
+    max_tokens: Optional[int] = None
+    model_config = dict(extra="allow")
+
+
+@router.cbv
+class FastAPIAI:
+    app: StructuredApp = DependsOnApp
+    config: GalaxyAppConfiguration = depends(GalaxyAppConfiguration)
+
+    @router.post("/api/plugins/{plugin_name}/chat/completions", unstable=True)
+    @limiter.limit("30/minute")
+    async def plugins_chat_adapter(
+        self,
+        request: Request,
+        payload: ChatCompletionRequest = Body(...),
+        user: User = DependsOnUser,
+        plugin_name: str = Path(
+            ...,
+            title="Plugin Name",
+            description="Visualization plugin name used to resolve the AI prompt.",
+            examples=["jupyterlite"],
+        ),
+    ):
+        registry = self.app.visualizations_registry
+        if registry:
+            try:
+                plugin = registry.get_plugin(plugin_name)
+            except ObjectNotFound:
+                return self.create_error(f"Plugin does not exist: {plugin_name}.")
+            plugin_specs = plugin and plugin.config.get("specs")
+            plugin_ai_prompt = plugin_specs and plugin_specs.get("ai_prompt")
+            if plugin_ai_prompt:
+                return await self._open_ai_adapter(payload, plugin_ai_prompt)
+            else:
+                return self.create_error("Selected plugin has no AI prompt.")
+        else:
+            return self.create_error("Visualization registry is not available.")
+
+    async def _open_ai_adapter(
+        self,
+        payload: ChatCompletionRequest,
+        prompt: str,
+    ):
+        """Galaxy managed chat completion adapter with prompt injection"""
+
+        # Collect configuration
+        ai_api_key = self.config.ai_api_key
+        ai_api_base_url = self.config.ai_api_base_url
+        ai_model = self.config.ai_model
+        if ai_api_key is None:
+            return self.create_error("AI service not configured: API key is required.")
+        if ai_model is None:
+            return self.create_error("AI service not configured: Model is required.")
+
+        # Limit max tokens
+        max_tokens = min(payload.max_tokens or TOKENS_DEFAULT, TOKENS_MAX)
+
+        # Validate messages
+        messages: list[ChatCompletionMessageParam] = cast(
+            list[ChatCompletionMessageParam],
+            [
+                dict(role="system", content=GALAXY_PROMPT),
+                dict(role="system", content=prompt),
+            ],
+        )
+        original_messages = payload.messages
+        for msg in original_messages:
+            role = msg.role
+            content = msg.content
+            tool_calls = msg.tool_calls
+            if role == "assistant":
+                msg_dict: dict[str, Any] = dict(role="assistant")
+                if content is not None:
+                    msg_dict["content"] = content
+                if isinstance(tool_calls, list):
+                    msg_dict["tool_calls"] = tool_calls
+                if len(msg_dict) > 1:
+                    messages.append(cast(ChatCompletionMessageParam, msg_dict))
+            elif role in ("user", "tool") and isinstance(content, str):
+                messages.append(cast(ChatCompletionMessageParam, dict(role=role, content=content)))
+            else:
+                continue
+            if len(messages) >= MAX_MESSAGES:
+                return self.create_error("You have exceeded the number of maximum messages.")
+
+        # Detect streaming flag
+        stream = payload.stream is True
+
+        # Limit number and size of tools
+        tools: list[ChatCompletionToolParam] = []
+        original_tools = payload.tools or []
+        if len(original_tools) <= MAX_TOOLS:
+            for tool in original_tools:
+                tool_dict = tool.model_dump()
+                size = len(json.dumps(tool_dict, separators=(",", ":")).encode("utf-8"))
+                if size > MAX_TOOL_BYTES:
+                    return self.create_error("Tool schema too large.")
+                tools.append(cast(ChatCompletionToolParam, tool_dict))
+        else:
+            return self.create_error("Number of tools exceeded or invalid tools list.")
+
+        # Build openai client with timeout
+        client_kwargs = dict(api_key=ai_api_key, timeout=TIMEOUT)
+        if ai_api_base_url:
+            client_kwargs["base_url"] = ai_api_base_url
+        try:
+            client = AsyncOpenAI(**client_kwargs)
+        except Exception as e:
+            log.debug("Failed to initialize OpenAI client.", exc_info=e)
+            return self.create_error("Failed to initialize OpenAI client.", 500)
+
+        # Connect to ai provider
+        log.info(f"Proxying to {ai_model}, tokens: {max_tokens}.")
+        try:
+            response = await client.chat.completions.create(
+                max_tokens=max_tokens,
+                messages=messages,
+                model=ai_model,
+                stream=stream,
+                temperature=TEMPERATURE,
+                tools=tools,
+                top_p=TOP_P,
+            )
+        except APIError as e:
+            log.debug("Failed to complete OpenAI request.", exc_info=e)
+            status_code = getattr(e, "status_code", 500)
+            if hasattr(e, "body") and isinstance(e.body, dict):
+                return JSONResponse(content=dict(error=e.body), status_code=status_code)
+            return self.create_error("Failed to complete OpenAI request.", status_code)
+
+        # Parse response
+        if stream:
+            stream_response: AsyncStream[ChatCompletionChunk] = cast(AsyncStream[ChatCompletionChunk], response)
+
+            async def generate():
+                try:
+                    async for chunk in stream_response:
+                        yield f"data: {json.dumps(chunk.model_dump())}\n\n"
+                    yield "data: [DONE]\n\n"
+                finally:
+                    await client.close()
+
+            return StreamingResponse(
+                generate(),
+                media_type="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "Connection": "keep-alive",
+                    "X-Accel-Buffering": "no",
+                },
+            )
+        else:
+            completion_response: ChatCompletion = cast(ChatCompletion, response)
+            return JSONResponse(content=completion_response.model_dump())
+
+    def create_error(self, message: str, status_code=400):
+        """Error handling helper."""
+        log.debug(message)
+        return JSONResponse(content=dict(error=dict(message=message)), status_code=status_code)
 
 
 class PluginsController(BaseGalaxyAPIController):
@@ -60,5 +300,5 @@ class PluginsController(BaseGalaxyAPIController):
 
     def _get_registry(self):
         if not self.app.visualizations_registry:
-            raise exceptions.MessageException("The visualization registry has not been configured.")
+            raise MessageException("The visualization registry has not been configured.")
         return self.app.visualizations_registry

--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -8,6 +8,12 @@ from fastapi import (
     Request,
 )
 from fastapi.openapi.constants import REF_TEMPLATE
+from slowapi import (
+    _rate_limit_exceeded_handler,
+    Limiter,
+)
+from slowapi.errors import RateLimitExceeded
+from slowapi.util import get_remote_address
 from starlette.middleware.cors import CORSMiddleware
 
 from galaxy.schema.generics import CustomJsonSchema
@@ -170,6 +176,8 @@ def initialize_fast_app(gx_wsgi_webapp, gx_app):
     app = get_fastapi_instance(root_path=root_path)
     add_exception_handler(app)
     add_galaxy_middleware(app, gx_app)
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore[arg-type]
     if gx_app.config.use_access_logging_middleware:
         add_raw_context_middlewares(app)
     else:
@@ -185,6 +193,18 @@ def initialize_fast_app(gx_wsgi_webapp, gx_app):
         return parent_app
     return app
 
+
+def galaxy_rate_limit_key(request: Request) -> str:
+    api_key = request.headers.get("x-api-key") or request.query_params.get("key")
+    if api_key:
+        return f"api_key:{api_key}"
+    session_key = request.cookies.get("galaxysession")
+    if session_key:
+        return f"session:{session_key}"
+    return get_remote_address(request)
+
+
+limiter = Limiter(key_func=galaxy_rate_limit_key)
 
 __all__ = (
     "add_galaxy_middleware",

--- a/test/integration/test_plugins.py
+++ b/test/integration/test_plugins.py
@@ -1,0 +1,187 @@
+import os
+from typing import (
+    Any,
+    cast,
+)
+from unittest.mock import (
+    AsyncMock,
+    MagicMock,
+    patch,
+)
+
+import pytest
+from openai import APIError
+
+from galaxy_test.driver.integration_util import IntegrationTestCase
+
+openai = pytest.importorskip("openai")
+
+TEST_VISUALIZATION_PLUGINS_DIR = os.path.join(os.path.dirname(__file__), "test_visualization_plugins")
+
+
+class TestAiApi(IntegrationTestCase):
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config) -> None:
+        config["ai_api_key"] = "ai_api_key"
+        config["ai_api_base_url"] = "ai_api_base_url"
+        config["ai_model"] = "ai_model"
+        config["visualization_plugins_directory"] = TEST_VISUALIZATION_PLUGINS_DIR
+
+    def _create_payload(self, extra=None):
+        payload = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [],
+        }
+        if extra:
+            payload.update(extra)
+        return payload
+
+    def _post_payload(self, payload=None, anon=False):
+        return self._post("plugins/jupyterlite/chat/completions", payload, json=True, anon=anon)
+
+    @patch("galaxy.webapps.galaxy.api.plugins.AsyncOpenAI")
+    def test_non_streaming_success(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {"id": "test", "choices": []}
+        mock_instance = MagicMock()
+        mock_instance.chat.completions.create = AsyncMock(return_value=mock_response)
+        mock_client.return_value = mock_instance
+        payload = self._create_payload()
+        response = self._post_payload(payload, anon=False)
+        self._assert_status_code_is(response, 200)
+        assert response.json()["id"] == "test"
+
+    @patch("galaxy.webapps.galaxy.api.plugins.AsyncOpenAI")
+    def test_streaming_success(self, mock_client):
+        async def stream_gen():
+            chunk1 = MagicMock()
+            chunk1.model_dump.return_value = {"choices": [{"delta": {"content": "hello"}}]}
+            chunk2 = MagicMock()
+            chunk2.model_dump.return_value = {"choices": [{"delta": {"content": "world"}}]}
+            yield chunk1
+            yield chunk2
+
+        mock_instance = MagicMock()
+        mock_instance.chat.completions.create = AsyncMock(return_value=stream_gen())
+        mock_instance.close = AsyncMock()
+        mock_client.return_value = mock_instance
+        payload = self._create_payload({"stream": True})
+        response = self._post_payload(payload, anon=False)
+        self._assert_status_code_is(response, 200)
+        body = response.text
+        assert body.count("data:") == 3
+        assert "hello" in body
+        assert "world" in body
+        assert body.rstrip().endswith("data: [DONE]")
+        assert mock_instance.chat.completions.create.called
+        assert mock_instance.close.called
+
+    def test_tools_exceed_max(self):
+        payload = self._create_payload(
+            {"tools": [{"type": "function", "function": {"name": "f", "parameters": {}}}] * 129}
+        )
+        response = self._post_payload(payload)
+        assert "Number of tools exceeded" in response.json()["error"]["message"]
+
+    def test_tool_schema_too_large(self):
+        big_params = {"x": "a" * 20000}
+        payload = self._create_payload(
+            {"tools": [{"type": "function", "function": {"name": "f", "parameters": big_params}}]}
+        )
+        response = self._post_payload(payload)
+        assert "Tool schema too large" in response.json()["error"]["message"]
+
+    def test_exceed_max_messages(self):
+        msgs = {"messages": [{"role": "user", "content": "x"}] * (1024 + 1)}
+        payload = self._create_payload(msgs)
+        response = self._post_payload(payload)
+        assert "You have exceeded the number of maximum messages" in response.json()["error"]["message"]
+
+    @patch("galaxy.webapps.galaxy.api.plugins.AsyncOpenAI")
+    def test_assistant_content_and_tool_calls_preserved(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {"id": "test", "choices": []}
+        mock_instance = MagicMock()
+        mock_instance.chat.completions.create = AsyncMock(return_value=mock_response)
+        mock_client.return_value = mock_instance
+        payload = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": "I will call a tool",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "choose_process",
+                                "arguments": "{}",
+                            },
+                        }
+                    ],
+                }
+            ],
+            "tools": [],
+        }
+        response = self._post_payload(payload)
+        self._assert_status_code_is(response, 200)
+        call_kwargs = mock_instance.chat.completions.create.call_args.kwargs
+        forwarded_messages = call_kwargs["messages"]
+        assistant_msgs = [m for m in forwarded_messages if m["role"] == "assistant"]
+        assert len(assistant_msgs) == 1
+        assert assistant_msgs[0]["content"] == "I will call a tool"
+        assert "tool_calls" in assistant_msgs[0]
+        assert assistant_msgs[0]["tool_calls"][0]["function"]["name"] == "choose_process"
+        assert assistant_msgs[0]["tool_calls"][0]["function"]["arguments"] == "{}"
+
+    @patch("galaxy.webapps.galaxy.api.plugins.AsyncOpenAI")
+    def test_tool_description_preserved(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {"id": "test", "choices": []}
+        mock_instance = MagicMock()
+        mock_instance.chat.completions.create = AsyncMock(return_value=mock_response)
+        mock_client.return_value = mock_instance
+        payload = self._create_payload(
+            {
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "choose_process",
+                            "description": "Select a processing step",
+                            "parameters": {"type": "object"},
+                        },
+                    }
+                ]
+            }
+        )
+        response = self._post_payload(payload)
+        self._assert_status_code_is(response, 200)
+        call_kwargs = mock_instance.chat.completions.create.call_args.kwargs
+        forwarded_tools = call_kwargs["tools"]
+        assert forwarded_tools[0]["function"]["description"] == "Select a processing step"
+
+    @patch("galaxy.webapps.galaxy.api.plugins.AsyncOpenAI")
+    def test_provider_error_body_forwarded(self, mock_client):
+        class MockOpenAIError(APIError):
+            def __init__(self):
+                super().__init__(
+                    message="original error message",
+                    request=cast(Any, object()),
+                    body={
+                        "message": "original error message",
+                        "type": "api_error",
+                        "param": None,
+                        "code": None,
+                    },
+                )
+                self.status_code = 404
+
+        mock_instance = MagicMock()
+        mock_instance.chat.completions.create = AsyncMock(side_effect=MockOpenAIError())
+        mock_client.return_value = mock_instance
+        response = self._post_payload(self._create_payload())
+        self._assert_status_code_is(response, 404)
+        body = response.json()
+        assert body["error"]["message"] == "original error message"
+        assert body["error"]["type"] == "api_error"

--- a/test/integration/test_visualization_plugins/jupyterlite/static/jupyterlite.xml
+++ b/test/integration/test_visualization_plugins/jupyterlite/static/jupyterlite.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<visualization name="JupyterLite Test" hidden="true">
+    <description>Test fixture for AI chat integration tests</description>
+    <data_sources>
+        <data_source>
+            <model_class>HistoryDatasetAssociation</model_class>
+        </data_source>
+    </data_sources>
+    <entry_point entry_point_type="script" src="script.js" />
+    <specs>
+        <ai_prompt>test prompt</ai_prompt>
+    </specs>
+</visualization>


### PR DESCRIPTION
This PR enables the AI completions adapter API on the European Galaxy instance (usegalaxy.eu) to support JupyterLite AI functionality. The required visualization plugins are already available. This PR exposes the backend adapter API needed for JupyterLite to submit chat completion requests to configured providers.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
