### PR TITLE
Fix HTCondor runner unwatching jobs when stopping containers

### DIFF
--- a/lib/galaxy/jobs/runners/condor.py
+++ b/lib/galaxy/jobs/runners/condor.py
@@ -234,7 +234,6 @@ class CondorJobRunner(AsynchronousJobRunner):
                         new_watch_list.append(tcjs)
                     else:
                         cjs = tcjs
-                        break
                 self.watched = new_watch_list
                 self._stop_container(job_wrapper)
                 # self.watched.append(cjs)


### PR DESCRIPTION
When the method `stop_job()` of the HTCondor job runner is called to stop a job running in a container, it locates the adequate `CondorJobState` object in the list of watched items by comparing HTCondor job id of each watched item with the HTCondor job id from the job wrapper that has been passed as an argument.

When there's a match, the correct `CondorJobState` is selected, but immediately afterwards there's a break statement with the effect that the remaining jobs in the list of watched items are discarded.

Remove the break statement to keep all jobs in the watchlist but the one that is being stopped.

Closes https://github.com/usegalaxy-eu/issues/issues/865.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
