### PR TITLE
Update locuszoom package version to 0.0.9

### DIFF
--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -53,7 +53,7 @@ kepler:
     version: 0.0.3
 locuszoom:
     package: "@galaxyproject/locuszoom"
-    version: 0.0.7
+    version: 0.0.9
 molstar:
     package: "@galaxyproject/molstar"
     version: 0.0.4


### PR DESCRIPTION
This PR changes the **locuszoom** version used in Visualisations from **0.0.7** to **0.0.9**

#### Important features in 0.0.9 include:

- Change chromosome input type from **Integer** to **String** in order to be able to plot GWAS results from genotyping data with chromosomes that have non-numeric names. 
- **Playwright** tests have also been added to locuszoom. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
