### PR TITLE
Patch `ToolDataPathFiles` to walk over `self.tool_data_path` every 10 minutes

### DIFF
--- a/lib/galaxy/tool_util/data/__init__.py
+++ b/lib/galaxy/tool_util/data/__init__.py
@@ -93,7 +93,7 @@ class ToolDataPathFiles:
 
     @property
     def tool_data_path_files(self) -> Set[str]:
-        if time.time() - self.update_time > 1:
+        if time.time() - self.update_time > 600:
             self.update_files()
         return self._tool_data_path_files
 


### PR DESCRIPTION
`ToolDataPathFiles.exists()` is called during the loading process of data tables. `ToolDataPathFiles` holds a view of the contents of the tool data directory `tool_data_path` that is refreshed if calls to `exist()` are spaced at least by one second.

On NFS, this is a complete performance killer. Calls to `exists()` will frequently be spaced by more than one second, causing an almost endless loop (hours and hours) of tool data dir walks.

Patch `ToolDataPathFiles` to space walks 10 minutes apart so that Celery workers have a chance to boot.
